### PR TITLE
chore(ui): drop deprecated baseUrl from tsconfig

### DIFF
--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@repo/ui/*": ["./src/*"]
     },


### PR DESCRIPTION
Removes `baseUrl` from `packages/ui/tsconfig.json` — it's unused (paths resolve fine without it since TS 4.1) and blocks the TypeScript 6 bump (#48).

Unblocks #48.