### PR TITLE
chore: migrate to @varlock/cloudflare-integration

### DIFF
--- a/apps/cv/package.json
+++ b/apps/cv/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite dev --port 3001",
     "build": "vite build",
-    "deploy": "varlock run -- sh -c 'APP_ENV=production vite build && wrangler deploy'",
+    "deploy": "APP_ENV=production bun run build && APP_ENV=production varlock-wrangler deploy",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
@@ -17,7 +17,7 @@
     "@tanstack/react-router": "latest",
     "@tanstack/react-start": "latest",
     "@varlock/bitwarden-plugin": "^0.0.6",
-    "@varlock/vite-integration": "^0.2.10",
+    "@varlock/cloudflare-integration": "^0.1.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "tailwindcss": "^4.2.4",

--- a/apps/cv/vite.config.ts
+++ b/apps/cv/vite.config.ts
@@ -1,16 +1,17 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
-import { varlockVitePlugin } from "@varlock/vite-integration";
+import { varlockCloudflareVitePlugin } from "@varlock/cloudflare-integration";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [
-    varlockVitePlugin({ ssrInjectMode: "resolved-env" }),
     tailwindcss(),
-    cloudflare({ inspectorPort: 9230, viteEnvironment: { name: "ssr" } }),
+    varlockCloudflareVitePlugin({
+      inspectorPort: 9230,
+      viteEnvironment: { name: "ssr" },
+    }),
     tanstackStart(),
     react(),
     tsconfigPaths(),

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite dev --port 3002",
     "build": "vite build",
-    "deploy": "varlock run -- sh -c 'APP_ENV=production vite build && wrangler deploy'",
+    "deploy": "APP_ENV=production bun run build && APP_ENV=production varlock-wrangler deploy",
     "check-types": "varlock typegen && tsc --noEmit"
   },
   "dependencies": {
@@ -16,7 +16,7 @@
     "@tanstack/react-router": "latest",
     "@tanstack/react-start": "latest",
     "@varlock/bitwarden-plugin": "^0.0.6",
-    "@varlock/vite-integration": "^0.2.10",
+    "@varlock/cloudflare-integration": "^0.1.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "tailwindcss": "^4.2.4",

--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -1,16 +1,17 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
-import { varlockVitePlugin } from "@varlock/vite-integration";
+import { varlockCloudflareVitePlugin } from "@varlock/cloudflare-integration";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [
-    varlockVitePlugin({ ssrInjectMode: "resolved-env" }),
     tailwindcss(),
-    cloudflare({ inspectorPort: 9231, viteEnvironment: { name: "ssr" } }),
+    varlockCloudflareVitePlugin({
+      inspectorPort: 9231,
+      viteEnvironment: { name: "ssr" },
+    }),
     tanstackStart(),
     react(),
     tsconfigPaths(),

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "varlock run -- vite dev --port 3000",
+    "dev": "vite dev --port 3000",
     "build": "vite build",
-    "deploy": "varlock run -- sh -c 'APP_ENV=production vite build && wrangler deploy'",
+    "deploy": "APP_ENV=production bun run build && APP_ENV=production varlock-wrangler deploy",
     "check-types": "varlock typegen && tsc --noEmit"
   },
   "dependencies": {
@@ -21,7 +21,7 @@
     "@tanstack/react-start": "latest",
     "@types/mdx": "^2.0.13",
     "@varlock/bitwarden-plugin": "^0.0.6",
-    "@varlock/vite-integration": "^0.2.10",
+    "@varlock/cloudflare-integration": "^0.1.0",
     "motion": "^12.38.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -1,17 +1,15 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import mdx from "@mdx-js/rollup";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
-import { varlockVitePlugin } from "@varlock/vite-integration";
+import { varlockCloudflareVitePlugin } from "@varlock/cloudflare-integration";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [
-    varlockVitePlugin({ ssrInjectMode: "resolved-env" }),
     tailwindcss(),
-    cloudflare({ viteEnvironment: { name: "ssr" } }),
+    varlockCloudflareVitePlugin({ viteEnvironment: { name: "ssr" } }),
     tanstackStart(),
     mdx(),
     react(),

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "my-stuff",
       "dependencies": {
-        "@varlock/vite-integration": "^0.2.10",
+        "@varlock/cloudflare-integration": "^0.1.0",
         "date-fns": "^4.1.0",
         "varlock": "^0.9.0",
       },
@@ -29,7 +29,7 @@
         "@tanstack/react-router": "latest",
         "@tanstack/react-start": "latest",
         "@varlock/bitwarden-plugin": "^0.0.6",
-        "@varlock/vite-integration": "^0.2.10",
+        "@varlock/cloudflare-integration": "^0.1.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "tailwindcss": "^4.2.4",
@@ -57,7 +57,7 @@
         "@tanstack/react-router": "latest",
         "@tanstack/react-start": "latest",
         "@varlock/bitwarden-plugin": "^0.0.6",
-        "@varlock/vite-integration": "^0.2.10",
+        "@varlock/cloudflare-integration": "^0.1.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "tailwindcss": "^4.2.4",
@@ -93,7 +93,7 @@
         "@tanstack/react-start": "latest",
         "@types/mdx": "^2.0.13",
         "@varlock/bitwarden-plugin": "^0.0.6",
-        "@varlock/vite-integration": "^0.2.10",
+        "@varlock/cloudflare-integration": "^0.1.0",
         "motion": "^12.38.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -678,7 +678,7 @@
 
     "@varlock/bitwarden-plugin": ["@varlock/bitwarden-plugin@0.0.6", "", { "peerDependencies": { "varlock": "^0.7.0" } }, "sha512-38eibxn/2AXlPjk/6b/SLQrtpdaqfEHIvzNcY36a1Hw0hokXReRCnpGeuV95BsR2b3JJIqtIbGZ/2uwFkCHVtw=="],
 
-    "@varlock/vite-integration": ["@varlock/vite-integration@0.2.10", "", { "peerDependencies": { "varlock": "^0.7.2", "vite": ">=5" } }, "sha512-awd2fSWA/p/kR6eqX4+qCiVqVHhnMt01sjHCIBcuNq7qyTmyaet+9MSdPHd8TykeiectJhGPodzMj4Zw6cy8gA=="],
+    "@varlock/cloudflare-integration": ["@varlock/cloudflare-integration@0.1.0", "", { "peerDependencies": { "@cloudflare/vite-plugin": ">=1", "varlock": "^0.9.0", "vite": ">=5", "wrangler": ">=3" }, "optionalPeers": ["@cloudflare/vite-plugin", "vite", "wrangler"], "bin": { "varlock-wrangler": "bin/varlock-wrangler.js" } }, "sha512-2fIjRUEJfqvSIMch4T3//iEQWI5umPV0MMU0HfkuqKAcaou6mN8UIbRY6XPoeKFXoPe/cFo6jwWEiigfl8fxrQ=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "packages/*"
   ],
   "dependencies": {
-    "@varlock/vite-integration": "^0.2.10",
+    "@varlock/cloudflare-integration": "^0.1.0",
     "date-fns": "^4.1.0",
     "varlock": "^0.9.0"
   },


### PR DESCRIPTION
Per varlock docs (https://varlock.dev/integrations/cloudflare/#approach-2-with-the-vite-plugin), replace the split `@varlock/vite-integration` + `@cloudflare/vite-plugin` setup with the unified `varlockCloudflareVitePlugin`.

## Changes
- Swap `@varlock/vite-integration` → `@varlock/cloudflare-integration` (root + 3 apps)
- Replace the `varlockVitePlugin({ ssrInjectMode: "resolved-env" })` + `cloudflare(opts)` pair with a single `varlockCloudflareVitePlugin(opts)` call
- Deploy now runs `varlock-wrangler deploy` (handles secrets as wrangler secrets) instead of wrapping wrangler with `varlock run`
- Drop `varlock run --` prefix from `apps/www` dev script — the plugin handles env injection via miniflare bindings

## Verification
- `bun run check-types` — 4 tasks pass
- `bun run build` — all 3 apps (cv, playground, www) build cleanly
- Dev server, bitwarden secrets, and deploy flow should be exercised manually before merging