### PR TITLE
feat(playground): build animation gallery with 10 routes

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -17,6 +17,8 @@
     "@tanstack/react-start": "latest",
     "@varlock/bitwarden-plugin": "^0.0.6",
     "@varlock/cloudflare-integration": "^0.1.0",
+    "lenis": "^1.3.4",
+    "motion": "^12.38.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "tailwindcss": "^4.2.4",

--- a/apps/playground/src/animations/3d-stack.tsx
+++ b/apps/playground/src/animations/3d-stack.tsx
@@ -1,0 +1,361 @@
+import { useEffect, useMemo, useRef } from "react";
+
+const TOTAL_CARDS = 16;
+const FRICTION = 0.9;
+const TOUCH_SENSITIVITY = 0.8;
+const WHEEL_SENSITIVITY = 0.8;
+const TRACKPAD_SENSITIVITY = 1.0;
+const MIN_VELOCITY = 0.5;
+const TOUCH_VELOCITY_SMOOTHING = 0.4;
+const CACHE_THRESHOLD = 0.25;
+const TRACKPAD_DELTA_THRESHOLD = 50;
+const TRACKPAD_RESET_MS = 500;
+const WHEEL_HISTORY_SIZE = 5;
+const WILL_CHANGE_RADIUS = 2;
+
+const CARD_WIDTH = 120;
+const CARD_HEIGHT = 180;
+const CARD_SPACING = 65;
+const DIAGONAL_X_PER_Z = -0.25;
+const DIAGONAL_Y_PER_Z = 0;
+
+const TITLES = [
+  "Alpha",
+  "Beta",
+  "Gamma",
+  "Delta",
+  "Epsilon",
+  "Zeta",
+  "Eta",
+  "Theta",
+  "Iota",
+  "Kappa",
+  "Lambda",
+  "Mu",
+  "Nu",
+  "Xi",
+  "Omicron",
+  "Pi",
+];
+
+const mod = (n: number, m: number) => ((n % m) + m) % m;
+
+const wrapCentered = (value: number, range: number) => {
+  const half = range / 2;
+  return mod(value + half, range) - half;
+};
+
+const toPx = (value: number) => `${Math.round(value * 100) / 100}px`;
+
+const circularDistance = (a: number, b: number, size: number) => {
+  const direct = Math.abs(a - b);
+  return Math.min(direct, size - direct);
+};
+
+const getCardColor = (index: number) => {
+  const hue = (index * 137.508) % 360;
+  const saturation = 60 + (index % 30);
+  const lightness = 50 + (index % 20);
+  return `hsla(${hue}, ${saturation}%, ${lightness}%, 0.7)`;
+};
+
+export default function Stack() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const cardRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const scrollRef = useRef(0);
+
+  const transformCache = useRef({
+    z: [] as number[],
+    dx: [] as number[],
+    dy: [] as number[],
+    zIndex: [] as number[],
+    willChange: [] as string[],
+  });
+
+  const momentum = useRef({
+    velocity: 0,
+    touchStartY: null as number | null,
+    lastTime: 0,
+  });
+
+  const wheel = useRef({
+    deltaHistory: [] as number[],
+    isTrackpad: false,
+    lastTime: 0,
+  });
+
+  const geometry = useRef({
+    baseZ: [] as number[],
+    totalRange: TOTAL_CARDS * CARD_SPACING,
+  });
+
+  const animation = useRef({
+    rafId: null as number | null,
+    lastFrameTime: 0,
+  });
+
+  const cardData = useMemo(
+    () =>
+      Array.from({ length: TOTAL_CARDS }, (_, i) => ({
+        color: getCardColor(i),
+        title: TITLES[i % TITLES.length],
+      })),
+    []
+  );
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const recomputeGeometry = () => {
+      const totalRange = TOTAL_CARDS * CARD_SPACING;
+      const halfRange = totalRange / 2;
+      geometry.current.totalRange = totalRange;
+      geometry.current.baseZ = Array.from(
+        { length: TOTAL_CARDS },
+        (_, i) => i * CARD_SPACING - halfRange
+      );
+    };
+
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: physics loop is naturally branchy; refactoring would harm readability
+    const applyTransforms = () => {
+      const scrollPos = scrollRef.current;
+      const totalRange = geometry.current.totalRange;
+      const halfRange = totalRange / 2;
+      const cache = transformCache.current;
+
+      animation.current.lastFrameTime = performance.now();
+
+      const centerIdx = mod(
+        Math.round((halfRange - scrollPos) / CARD_SPACING),
+        TOTAL_CARDS
+      );
+
+      for (let i = 0; i < TOTAL_CARDS; i++) {
+        const el = cardRefs.current[i];
+        if (!el) {
+          continue;
+        }
+
+        const baseZ = geometry.current.baseZ[i] ?? i * CARD_SPACING - halfRange;
+        const z = wrapCentered(baseZ + scrollPos, totalRange);
+        const dx = z * DIAGONAL_X_PER_Z;
+        const dy = z * DIAGONAL_Y_PER_Z;
+        const zIndex = 10_000 - Math.floor(Math.abs(z));
+        const willChangeValue =
+          circularDistance(i, centerIdx, TOTAL_CARDS) <= WILL_CHANGE_RADIUS
+            ? "transform"
+            : "auto";
+
+        const cachedZ = cache.z[i];
+        if (
+          cachedZ !== undefined &&
+          Math.abs(z - cachedZ) < CACHE_THRESHOLD &&
+          Math.abs(dx - (cache.dx[i] ?? 0)) < CACHE_THRESHOLD &&
+          Math.abs(dy - (cache.dy[i] ?? 0)) < CACHE_THRESHOLD &&
+          cache.zIndex[i] === zIndex &&
+          cache.willChange[i] === willChangeValue
+        ) {
+          continue;
+        }
+
+        el.style.transform = `translate3d(calc(-50% + ${toPx(dx)}), calc(-50% + ${toPx(dy)}), ${toPx(z)})`;
+        if (cache.willChange[i] !== willChangeValue) {
+          el.style.willChange = willChangeValue;
+          cache.willChange[i] = willChangeValue;
+        }
+        if (cache.zIndex[i] !== zIndex) {
+          el.style.zIndex = String(zIndex);
+          cache.zIndex[i] = zIndex;
+        }
+        cache.z[i] = z;
+        cache.dx[i] = dx;
+        cache.dy[i] = dy;
+      }
+    };
+
+    const animationLoop = (time: number) => {
+      const maxOffset = geometry.current.totalRange;
+      let needsMoreFrames = false;
+
+      const v = momentum.current.velocity;
+      if (Math.abs(v) >= MIN_VELOCITY) {
+        const lastTime = momentum.current.lastTime || time;
+        const dt = Math.max(0.001, (time - lastTime) / 1000);
+        momentum.current.lastTime = time;
+        scrollRef.current = mod(scrollRef.current + v * dt, maxOffset);
+        momentum.current.velocity = v * FRICTION ** (dt * 60);
+        needsMoreFrames = true;
+      } else if (v !== 0) {
+        momentum.current.velocity = 0;
+      }
+
+      applyTransforms();
+
+      if (needsMoreFrames) {
+        animation.current.rafId = requestAnimationFrame(animationLoop);
+      } else {
+        animation.current.rafId = null;
+      }
+    };
+
+    const scheduleLoop = () => {
+      if (animation.current.rafId) {
+        return;
+      }
+      animation.current.rafId = requestAnimationFrame(animationLoop);
+    };
+
+    const updateScrollOffset = (delta: number) => {
+      scrollRef.current = mod(
+        scrollRef.current + delta,
+        geometry.current.totalRange
+      );
+      scheduleLoop();
+    };
+
+    const stopMomentum = () => {
+      momentum.current.velocity = 0;
+    };
+
+    const startMomentum = () => {
+      if (Math.abs(momentum.current.velocity) >= MIN_VELOCITY) {
+        momentum.current.lastTime = performance.now();
+        scheduleLoop();
+      }
+    };
+
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const now = performance.now();
+      const timeSinceLastWheel = now - wheel.current.lastTime;
+      if (timeSinceLastWheel > TRACKPAD_RESET_MS) {
+        wheel.current.deltaHistory = [];
+      }
+      wheel.current.lastTime = now;
+      const history = wheel.current.deltaHistory;
+      history.push(Math.abs(e.deltaY));
+      if (history.length > WHEEL_HISTORY_SIZE) {
+        history.shift();
+      }
+      const allSmall =
+        history.length >= WHEEL_HISTORY_SIZE &&
+        history.every((d) => d < TRACKPAD_DELTA_THRESHOLD) &&
+        e.deltaMode === 0;
+      wheel.current.isTrackpad = allSmall;
+      const sensitivity = wheel.current.isTrackpad
+        ? TRACKPAD_SENSITIVITY
+        : WHEEL_SENSITIVITY;
+      updateScrollOffset(e.deltaY * sensitivity);
+    };
+
+    const handleTouchStart = (e: TouchEvent) => {
+      stopMomentum();
+      const first = e.touches[0];
+      if (first) {
+        momentum.current.touchStartY = first.clientY;
+        momentum.current.lastTime = performance.now();
+        momentum.current.velocity = 0;
+      }
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      const first = e.touches[0];
+      if (momentum.current.touchStartY === null || !first) {
+        return;
+      }
+      e.preventDefault();
+      const currentY = first.clientY;
+      const now = performance.now();
+      const deltaY = momentum.current.touchStartY - currentY;
+      const timeDelta = Math.max(1, now - momentum.current.lastTime) / 1000;
+      const instantVelocity = deltaY / timeDelta;
+      momentum.current.velocity =
+        momentum.current.velocity * (1 - TOUCH_VELOCITY_SMOOTHING) +
+        instantVelocity * TOUCH_VELOCITY_SMOOTHING * TOUCH_SENSITIVITY;
+      updateScrollOffset(deltaY * TOUCH_SENSITIVITY);
+      momentum.current.touchStartY = currentY;
+      momentum.current.lastTime = now;
+    };
+
+    const handleTouchEnd = () => {
+      startMomentum();
+      momentum.current.touchStartY = null;
+    };
+
+    recomputeGeometry();
+    transformCache.current = {
+      z: [],
+      dx: [],
+      dy: [],
+      zIndex: [],
+      willChange: [],
+    };
+    animation.current.lastFrameTime = performance.now();
+    applyTransforms();
+
+    container.addEventListener("wheel", handleWheel, { passive: false });
+    container.addEventListener("touchstart", handleTouchStart, {
+      passive: true,
+    });
+    container.addEventListener("touchmove", handleTouchMove, {
+      passive: false,
+    });
+    container.addEventListener("touchend", handleTouchEnd, { passive: true });
+    container.addEventListener("touchcancel", handleTouchEnd, {
+      passive: true,
+    });
+
+    return () => {
+      container.removeEventListener("wheel", handleWheel);
+      container.removeEventListener("touchstart", handleTouchStart);
+      container.removeEventListener("touchmove", handleTouchMove);
+      container.removeEventListener("touchend", handleTouchEnd);
+      container.removeEventListener("touchcancel", handleTouchEnd);
+      stopMomentum();
+      if (animation.current.rafId) {
+        cancelAnimationFrame(animation.current.rafId);
+        animation.current.rafId = null;
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      className="relative h-96 w-96 cursor-pointer touch-none overflow-hidden rounded-lg bg-black/95"
+      ref={containerRef}
+    >
+      <div className="transform-3d pointer-events-none absolute inset-0 -rotate-x-39 -rotate-y-18 rotate-z-18 overflow-visible">
+        {cardData.map((card, index) => (
+          <div
+            className="transform-3d pointer-events-auto absolute top-1/2 left-1/2"
+            key={card.title}
+            ref={(el) => {
+              cardRefs.current[index] = el;
+            }}
+            style={{
+              width: CARD_WIDTH,
+              height: CARD_HEIGHT,
+              transform: "translate3d(-50%, -50%, 0px)",
+            }}
+          >
+            <div
+              className="absolute inset-0 flex -rotate-z-18 items-center justify-center rounded-sm border border-white/10"
+              style={{
+                width: CARD_WIDTH,
+                height: CARD_HEIGHT,
+                backgroundColor: card.color,
+              }}
+            >
+              <span className="select-none font-semibold text-[10px] text-white drop-shadow-lg">
+                {card.title}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/playground/src/animations/carousel.tsx
+++ b/apps/playground/src/animations/carousel.tsx
@@ -1,0 +1,302 @@
+import { useEffect, useRef } from "react";
+
+const COLORS = [
+  "linear-gradient(135deg, #f97316 0%, #ef4444 100%)",
+  "linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)",
+  "linear-gradient(135deg, #10b981 0%, #06b6d4 100%)",
+  "linear-gradient(135deg, #f59e0b 0%, #ec4899 100%)",
+  "linear-gradient(135deg, #6366f1 0%, #14b8a6 100%)",
+  "linear-gradient(135deg, #db2777 0%, #f97316 100%)",
+  "linear-gradient(135deg, #84cc16 0%, #22d3ee 100%)",
+  "linear-gradient(135deg, #a855f7 0%, #ec4899 100%)",
+  "linear-gradient(135deg, #0ea5e9 0%, #6366f1 100%)",
+  "linear-gradient(135deg, #facc15 0%, #f43f5e 100%)",
+];
+
+const FRICTION = 0.9;
+const WHEEL_SENS = 0.6;
+const DRAG_SENS = 1.0;
+const MAX_ROTATION = 28;
+const MAX_DEPTH = 140;
+const MIN_SCALE = 0.92;
+const SCALE_RANGE = 0.1;
+const GAP = 28;
+
+function mod(n: number, m: number): number {
+  return ((n % m) + m) % m;
+}
+
+export default function Carousel() {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const cardRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  const state = useRef({
+    items: [] as { el: HTMLDivElement | null; pos: number }[],
+    positions: new Float32Array(COLORS.length),
+    cardW: 300,
+    cardH: 400,
+    step: 0,
+    track: 0,
+    scrollPos: 0,
+    v: 0,
+    vwHalf: 0,
+    rafId: null as number | null,
+    lastTime: 0,
+  });
+
+  const dragState = useRef({
+    dragging: false,
+    lastPos: 0,
+    lastT: 0,
+    lastDelta: 0,
+  });
+
+  useEffect(() => {
+    const measure = () => {
+      const sample = cardRefs.current[0];
+      if (!sample) {
+        return;
+      }
+      const rect = sample.getBoundingClientRect();
+      const s = state.current;
+      s.cardW = rect.width || 300;
+      s.cardH = rect.height || 400;
+      s.step = s.cardW + GAP;
+      s.track = COLORS.length * s.step;
+      s.vwHalf = window.innerWidth * 0.5;
+      s.items = COLORS.map((_, i) => ({
+        el: cardRefs.current[i] ?? null,
+        pos: i * s.step,
+      }));
+      s.positions = new Float32Array(COLORS.length);
+    };
+
+    const transformFor = (screenPos: number) => {
+      const s = state.current;
+      const norm = Math.max(-1, Math.min(1, screenPos / s.vwHalf));
+      const absNorm = Math.abs(norm);
+      const invNorm = 1 - absNorm;
+      const rotation = -norm * MAX_ROTATION;
+      const tz = invNorm * MAX_DEPTH;
+      const scale = MIN_SCALE + invNorm * SCALE_RANGE;
+      return {
+        transform: `translate3d(${screenPos}px, -50%, ${tz}px) rotateY(${rotation}deg) scale(${scale})`,
+        z: tz,
+        norm,
+      };
+    };
+
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: physics loop with branch-heavy per-frame logic
+    const update = () => {
+      const s = state.current;
+      const half = s.track / 2;
+      let closestIdx = -1;
+      let closestDist = Number.POSITIVE_INFINITY;
+
+      for (let i = 0; i < s.items.length; i++) {
+        const item = s.items[i];
+        if (!item) {
+          continue;
+        }
+        let pos = item.pos - s.scrollPos;
+        if (pos < -half) {
+          pos += s.track;
+        }
+        if (pos > half) {
+          pos -= s.track;
+        }
+        s.positions[i] = pos;
+        const dist = Math.abs(pos);
+        if (dist < closestDist) {
+          closestDist = dist;
+          closestIdx = i;
+        }
+      }
+
+      const prevIdx = (closestIdx - 1 + s.items.length) % s.items.length;
+      const nextIdx = (closestIdx + 1) % s.items.length;
+
+      for (let i = 0; i < s.items.length; i++) {
+        const item = s.items[i];
+        if (!item) {
+          continue;
+        }
+        const pos = s.positions[i] ?? 0;
+        const { transform, z, norm } = transformFor(pos);
+        if (item.el) {
+          item.el.style.transform = transform;
+          item.el.style.zIndex = String(1000 + Math.round(z));
+          const isCore = i === closestIdx || i === prevIdx || i === nextIdx;
+          const blur = isCore ? 0 : 2 * Math.abs(norm) ** 1.1;
+          item.el.style.filter = `blur(${blur.toFixed(2)}px)`;
+        }
+      }
+    };
+
+    const tick = (t: number) => {
+      const s = state.current;
+      const dt = s.lastTime ? (t - s.lastTime) / 1000 : 0;
+      s.lastTime = t;
+      s.scrollPos = mod(s.scrollPos + s.v * dt, s.track);
+      const decay = FRICTION ** (dt * 60);
+      s.v *= decay;
+      if (Math.abs(s.v) < 0.02) {
+        s.v = 0;
+      }
+      if (s.v === 0 && !dragState.current.dragging) {
+        s.rafId = null;
+        return;
+      }
+      update();
+      s.rafId = requestAnimationFrame(tick);
+    };
+
+    const start = () => {
+      const s = state.current;
+      if (s.rafId) {
+        return;
+      }
+      s.lastTime = 0;
+      update();
+      s.rafId = requestAnimationFrame(tick);
+    };
+
+    const stop = () => {
+      const s = state.current;
+      if (s.rafId) {
+        cancelAnimationFrame(s.rafId);
+        s.rafId = null;
+      }
+    };
+
+    measure();
+    update();
+    start();
+
+    let resizeTimer: ReturnType<typeof setTimeout>;
+    const handleResize = () => {
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => {
+        const s = state.current;
+        const prevStep = s.step || 1;
+        const ratio = s.scrollPos / (COLORS.length * prevStep);
+        measure();
+        s.scrollPos = mod(ratio * s.track, s.track);
+        update();
+      }, 150);
+    };
+
+    const stage = stageRef.current;
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const s = state.current;
+      const delta =
+        Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
+      s.v += delta * WHEEL_SENS * 20;
+      if (!s.rafId) {
+        start();
+      }
+    };
+
+    const onPointerDown = (e: PointerEvent) => {
+      if (!stage) {
+        return;
+      }
+      const drag = dragState.current;
+      drag.dragging = true;
+      drag.lastPos = e.clientX;
+      drag.lastT = performance.now();
+      drag.lastDelta = 0;
+      stage.setPointerCapture(e.pointerId);
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      const drag = dragState.current;
+      if (!drag.dragging) {
+        return;
+      }
+      const s = state.current;
+      const now = performance.now();
+      const dPos = e.clientX - drag.lastPos;
+      const dt = Math.max(1, now - drag.lastT) / 1000;
+      s.scrollPos = mod(s.scrollPos - dPos * DRAG_SENS, s.track);
+      drag.lastDelta = dPos / dt;
+      drag.lastPos = e.clientX;
+      drag.lastT = now;
+      update();
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      const drag = dragState.current;
+      if (!drag.dragging) {
+        return;
+      }
+      drag.dragging = false;
+      stage?.releasePointerCapture(e.pointerId);
+      state.current.v = -drag.lastDelta * DRAG_SENS;
+      if (!state.current.rafId && state.current.v !== 0) {
+        start();
+      }
+    };
+
+    const handleVisibility = () => {
+      if (document.hidden) {
+        stop();
+      } else {
+        start();
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+    document.addEventListener("visibilitychange", handleVisibility);
+    stage?.addEventListener("wheel", onWheel, { passive: false });
+    stage?.addEventListener("pointerdown", onPointerDown);
+    stage?.addEventListener("pointermove", onPointerMove);
+    stage?.addEventListener("pointerup", onPointerUp);
+
+    return () => {
+      stop();
+      clearTimeout(resizeTimer);
+      window.removeEventListener("resize", handleResize);
+      document.removeEventListener("visibilitychange", handleVisibility);
+      stage?.removeEventListener("wheel", onWheel);
+      stage?.removeEventListener("pointerdown", onPointerDown);
+      stage?.removeEventListener("pointermove", onPointerMove);
+      stage?.removeEventListener("pointerup", onPointerUp);
+    };
+  }, []);
+
+  return (
+    <div
+      className="relative h-[80vh] w-full max-w-6xl cursor-grab select-none overflow-hidden rounded-lg active:cursor-grabbing"
+      ref={stageRef}
+      style={{ perspective: "1800px", touchAction: "none" }}
+    >
+      <div
+        className="absolute inset-0 z-10"
+        style={{ transformStyle: "preserve-3d" }}
+      >
+        {COLORS.map((bg, index) => (
+          <div
+            className="absolute top-1/2 left-1/2 isolate aspect-[4/5] w-[min(26vw,360px)] will-change-[transform,filter]"
+            key={bg}
+            ref={(el) => {
+              cardRefs.current[index] = el;
+            }}
+            style={{
+              backfaceVisibility: "hidden",
+              transformStyle: "preserve-3d",
+              transformOrigin: "90% center",
+            }}
+          >
+            <div
+              className="h-full w-full rounded-2xl shadow-2xl ring-1 ring-white/10"
+              style={{ background: bg }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/playground/src/animations/cursor.tsx
+++ b/apps/playground/src/animations/cursor.tsx
@@ -1,0 +1,27 @@
+import { motion, useSpring } from "motion/react";
+
+export default function Cursor() {
+  const x = useSpring(0, { mass: 0.1 });
+  const y = useSpring(0, { mass: 0.1 });
+  const opacity = useSpring(0);
+
+  return (
+    <div className="h-72 w-full max-w-2xl overflow-hidden rounded-md border border-muted-foreground/20">
+      <div
+        className="h-full w-full overflow-hidden"
+        onPointerEnter={() => opacity.set(1)}
+        onPointerLeave={() => opacity.set(0)}
+        onPointerMove={(e) => {
+          const bounds = e.currentTarget.getBoundingClientRect();
+          x.set(e.clientX - bounds.left - 24);
+          y.set(e.clientY - bounds.top - 24);
+        }}
+      >
+        <motion.div
+          className="h-10 w-10 rounded-full bg-red-500"
+          style={{ x, y, opacity }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/playground/src/animations/exposure.tsx
+++ b/apps/playground/src/animations/exposure.tsx
@@ -1,0 +1,368 @@
+import {
+  clamp,
+  frame,
+  type MotionValue,
+  mix,
+  motion,
+  progress,
+  useMotionValue,
+  useMotionValueEvent,
+  useTransform,
+} from "motion/react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+const ACCENT = "#f4d845";
+const EXPOSURE_VALUES = Array.from({ length: 41 }, (_, i) => -100 + i * 5);
+
+const colorFor = (value: number) => (value > 0 ? ACCENT : "#000");
+
+type NotchState = "ACTIVE" | "WAS_ACTIVE" | "INACTIVE";
+
+function ExposureNotch({
+  baseOpacity,
+  index,
+  totalItems,
+  pixelOffset,
+}: {
+  baseOpacity: number;
+  index: number;
+  totalItems: number;
+  pixelOffset: number;
+}) {
+  const [state, setState] = useState<NotchState>("INACTIVE");
+  const prevOffset = useRef(pixelOffset);
+  const stateRef = useRef(state);
+
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  useEffect(() => {
+    const latest = pixelOffset;
+    const prev = prevOffset.current;
+    prevOffset.current = latest;
+
+    const threshold = 6.5;
+    let isCurrentlyActive = false;
+    let crossedActiveZone = false;
+    const edgeThreshold = 1;
+
+    if (index === 0) {
+      isCurrentlyActive = latest >= -edgeThreshold;
+      crossedActiveZone = prev < -edgeThreshold && latest >= -edgeThreshold;
+    } else if (index === totalItems - 1) {
+      isCurrentlyActive = latest <= edgeThreshold;
+      crossedActiveZone = prev > edgeThreshold && latest <= edgeThreshold;
+    } else {
+      isCurrentlyActive = Math.abs(latest) < threshold;
+      const wasInside = Math.abs(prev) < threshold;
+      const signChanged = prev * latest <= 0;
+      crossedActiveZone = (wasInside || signChanged) && !isCurrentlyActive;
+    }
+
+    let nextState: NotchState | null = null;
+    const currentState = stateRef.current;
+
+    if (isCurrentlyActive) {
+      nextState = "ACTIVE";
+    } else if (currentState === "ACTIVE") {
+      nextState = "WAS_ACTIVE";
+    } else if (crossedActiveZone) {
+      frame.postRender(() => {
+        setState("ACTIVE");
+        frame.postRender(() => setState("WAS_ACTIVE"));
+      });
+      return;
+    }
+
+    if (nextState && currentState !== nextState) {
+      const finalState = nextState;
+      frame.postRender(() => setState(finalState));
+    }
+  }, [pixelOffset, index, totalItems]);
+
+  return (
+    <motion.div
+      animate={{
+        clipPath: state === "ACTIVE" ? "inset(0% 0 0 0)" : "inset(50% 0 0 0)",
+        opacity: state === "ACTIVE" ? 1 : baseOpacity,
+      }}
+      className="exp-notch"
+      initial={{ clipPath: "inset(50% 0 0 0)", opacity: baseOpacity }}
+      onAnimationComplete={() => {
+        if (state === "WAS_ACTIVE") {
+          setState("INACTIVE");
+        }
+      }}
+      style={{
+        backgroundColor: state === "ACTIVE" ? ACCENT : "#000",
+        willChange: "clip-path, opacity",
+      }}
+      transition={
+        state === "ACTIVE"
+          ? { type: false }
+          : { type: "spring", bounce: 0.2, duration: 0.8 }
+      }
+    />
+  );
+}
+
+function ProgressIndicator({ value }: { value: MotionValue<number> }) {
+  const [color, setColor] = useState(colorFor(value.get()));
+  const displayValue = useTransform(() => Math.round(value.get() * 100));
+  const positiveProgress = useTransform(displayValue, [0, 100], [0, 1]);
+  const negativeProgress = useTransform(displayValue, [-100, 0], [1, 0]);
+
+  useMotionValueEvent(displayValue, "change", (v) => {
+    setColor(colorFor(v));
+  });
+
+  const radius = 48;
+
+  return (
+    <motion.div
+      animate={{ "--exp-color": color } as unknown as Record<string, string>}
+      className="exp-progress"
+    >
+      <svg viewBox="0 0 100 100">
+        <title>Exposure indicator</title>
+        <circle className="exp-circle-border" cx="50" cy="50" r={radius} />
+        <motion.circle
+          className="exp-indicator exp-positive"
+          cx="50"
+          cy="50"
+          r={radius}
+          style={{ pathLength: positiveProgress, rotate: -90 }}
+        />
+        <motion.circle
+          className="exp-indicator exp-negative"
+          cx="50"
+          cy="50"
+          r={radius}
+          style={{ pathLength: negativeProgress, rotate: -90, scaleX: -1 }}
+        />
+      </svg>
+      <motion.div
+        className="exp-progress-value"
+        style={{ color: "var(--exp-color)" }}
+      >
+        {displayValue}
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function ExposureRail({ exposure }: { exposure: MotionValue<number> }) {
+  const stripRef = useRef<HTMLDivElement>(null);
+  const notchRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [offsets, setOffsets] = useState<number[]>(() =>
+    Array.from({ length: EXPOSURE_VALUES.length }, () => 0)
+  );
+
+  const measure = useCallback(() => {
+    const strip = stripRef.current;
+    if (!strip) {
+      return;
+    }
+    const rect = strip.getBoundingClientRect();
+    const center = rect.left + rect.width / 2;
+    const next = EXPOSURE_VALUES.map((_, i) => {
+      const el = notchRefs.current[i];
+      if (!el) {
+        return 0;
+      }
+      const r = el.getBoundingClientRect();
+      return r.left + r.width / 2 - center;
+    });
+    setOffsets(next);
+
+    const maxInset = strip.scrollWidth - strip.clientWidth;
+    if (maxInset <= 0) {
+      return;
+    }
+    const newExposure = clamp(
+      -1,
+      1,
+      mix(-1, 1, progress(0, maxInset, strip.scrollLeft))
+    );
+    exposure.set(newExposure);
+  }, [exposure]);
+
+  useLayoutEffect(() => {
+    const strip = stripRef.current;
+    if (!strip) {
+      return;
+    }
+
+    const maxInset = strip.scrollWidth - strip.clientWidth;
+    if (maxInset > 0) {
+      strip.scrollLeft = mix(0, maxInset, 0.5);
+      exposure.set(0);
+    }
+
+    strip.addEventListener("scroll", measure, { passive: true });
+    const ro = new ResizeObserver(measure);
+    ro.observe(strip);
+    window.addEventListener("resize", measure);
+    measure();
+
+    return () => {
+      strip.removeEventListener("scroll", measure);
+      ro.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [exposure, measure]);
+
+  return (
+    <div className="exp-strip" ref={stripRef}>
+      <div className="exp-strip-inner">
+        {EXPOSURE_VALUES.map((value, index) => (
+          <div
+            className="exp-notch-container"
+            key={value}
+            ref={(el) => {
+              notchRefs.current[index] = el;
+            }}
+          >
+            <ExposureNotch
+              baseOpacity={value % 50 === 0 ? 0.6 : 0.3}
+              index={index}
+              pixelOffset={offsets[index] ?? 0}
+              totalItems={EXPOSURE_VALUES.length}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function Exposure() {
+  const exposure = useMotionValue(0);
+  const filter = useTransform(
+    exposure,
+    [-1, 1],
+    ["brightness(0%)", "brightness(200%)"]
+  );
+
+  return (
+    <>
+      <div className="exp-container">
+        <div className="exp-subject">
+          <motion.div
+            className="exp-subject-fill"
+            style={{
+              filter,
+              background:
+                "linear-gradient(135deg, #f97316 0%, #db2777 35%, #6366f1 70%, #0ea5e9 100%)",
+            }}
+          />
+        </div>
+        <ProgressIndicator value={exposure} />
+        <div className="exp-slider">
+          <ExposureRail exposure={exposure} />
+        </div>
+      </div>
+      <ExposureStyles />
+    </>
+  );
+}
+
+function ExposureStyles() {
+  return (
+    <style>{`
+      .exp-container {
+        max-width: 500px;
+        width: 100%;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 24px;
+        padding: 20px;
+        --exp-color: #000;
+      }
+      .exp-subject {
+        width: 100%;
+        max-height: 300px;
+        aspect-ratio: 16/10;
+        border-radius: 8px;
+        overflow: hidden;
+      }
+      .exp-subject-fill {
+        width: 100%;
+        height: 100%;
+      }
+      .exp-progress {
+        width: 75px;
+        height: 75px;
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .exp-progress svg {
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+      }
+      .exp-circle-border {
+        fill: rgba(0,0,0,0.07);
+        stroke: var(--exp-color);
+        stroke-width: 3;
+        opacity: 0.3;
+      }
+      .exp-indicator {
+        fill: none;
+        stroke-width: 3;
+      }
+      .exp-positive { stroke: ${ACCENT}; }
+      .exp-negative { stroke: #000; }
+      .exp-progress-value {
+        font-size: 18px;
+        font-weight: 600;
+        position: absolute;
+        font-variant-numeric: tabular-nums;
+      }
+      .exp-slider {
+        position: relative;
+        height: 40px;
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        mask-image: linear-gradient(to right, transparent 0%, #000 20%, #000 80%, transparent 100%);
+        -webkit-mask-image: linear-gradient(to right, transparent 0%, #000 20%, #000 80%, transparent 100%);
+      }
+      .exp-strip {
+        height: 100%;
+        width: 100%;
+        padding: 0 calc(50% - 6.5px);
+        overflow-x: auto;
+        overflow-y: hidden;
+        scrollbar-width: none;
+        box-sizing: border-box;
+      }
+      .exp-strip::-webkit-scrollbar { display: none; }
+      .exp-strip-inner {
+        display: flex;
+        width: max-content;
+      }
+      .exp-notch-container { padding: 0 5px; }
+      .exp-notch {
+        width: 3px;
+        height: 40px;
+        background-color: rgba(0,0,0,0.3);
+        border-radius: 1px;
+      }
+    `}</style>
+  );
+}

--- a/apps/playground/src/animations/fake-3d-stack.tsx
+++ b/apps/playground/src/animations/fake-3d-stack.tsx
@@ -1,0 +1,182 @@
+import { ReactLenis, useLenis } from "lenis/react";
+import {
+  motion,
+  useMotionTemplate,
+  useMotionValue,
+  useMotionValueEvent,
+  useSpring,
+  useTransform,
+} from "motion/react";
+import { useEffect, useRef, useState } from "react";
+
+const TOTAL_CARDS = 10;
+const CARD_WIDTH = 120;
+const CARD_HEIGHT = 180;
+
+const TITLES = [
+  "Alpha",
+  "Beta",
+  "Gamma",
+  "Delta",
+  "Epsilon",
+  "Zeta",
+  "Eta",
+  "Theta",
+  "Iota",
+  "Kappa",
+];
+
+const getCardColor = (index: number) => {
+  const hue = (index * 137.508) % 360;
+  const saturation = 60 + (index % 30);
+  const lightness = 50 + (index % 20);
+  return `hsla(${hue}, ${saturation}%, ${lightness}%, 0.7)`;
+};
+
+function remap(
+  value: number,
+  fromMin: number,
+  fromMax: number,
+  toMin: number,
+  toMax: number
+) {
+  return ((value - fromMin) / (fromMax - fromMin)) * (toMax - toMin) + toMin;
+}
+
+interface DriftCardProps {
+  children: React.ReactNode;
+  containerHeight: number;
+  containerWidth: number;
+  count: number;
+  index: number;
+}
+
+function DriftCard({
+  index,
+  count,
+  containerWidth,
+  containerHeight,
+  children,
+}: DriftCardProps) {
+  const scrollProgress = useMotionValue(0);
+  const isTouch =
+    typeof window !== "undefined" &&
+    window.matchMedia("(pointer: coarse)").matches;
+
+  const cardOffset = index / count;
+  const initialZIndex = Math.floor((cardOffset % 1) * count);
+  const [relativeZIndex, setRelativeZIndex] = useState(initialZIndex);
+  const scale = useMotionValue(1);
+  const springScale = useSpring(scale, {
+    stiffness: 100,
+    damping: 10,
+    mass: 0.5,
+  });
+
+  const loopedProgress = useTransform(
+    scrollProgress,
+    (p: number) => (p + index / count) % 1
+  );
+
+  useMotionValueEvent(loopedProgress, "change", (latest) => {
+    setRelativeZIndex(Math.floor(latest * count));
+  });
+
+  const x = useTransform(loopedProgress, (p: number) =>
+    remap(p, 0, 1, containerWidth, -CARD_WIDTH - CARD_WIDTH / 2)
+  );
+  const y = useTransform(loopedProgress, (p: number) =>
+    remap(p, 0, 1, -CARD_HEIGHT, containerHeight + CARD_HEIGHT / 2)
+  );
+
+  useLenis((lenis: { progress: number; velocity: number }) => {
+    scrollProgress.set(isTouch ? 1 - lenis.progress : lenis.progress);
+  });
+
+  const transform = useMotionTemplate`translate(${x}px, ${y}px) skewY(10deg) scale(${springScale})`;
+
+  return (
+    <motion.div
+      className="absolute flex items-center justify-center"
+      style={{
+        height: CARD_HEIGHT,
+        width: CARD_WIDTH,
+        top: -CARD_HEIGHT / 2,
+        zIndex: relativeZIndex,
+        transform,
+      }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+function DriftCards({ width, height }: { width: number; height: number }) {
+  return (
+    <div className="relative h-full w-full">
+      <ReactLenis
+        className="scrollbar-none h-full w-full overflow-hidden rounded-sm"
+        options={{
+          infinite: true,
+          syncTouch: true,
+          syncTouchLerp: 0.2,
+          duration: 2,
+        }}
+      >
+        <div className="h-[1000px] w-full" />
+        <div className="absolute top-0 right-0 mx-auto flex h-full w-full flex-col items-center overflow-hidden rounded-sm">
+          {Array.from({ length: TOTAL_CARDS }).map((_, i) => (
+            <DriftCard
+              containerHeight={height}
+              containerWidth={width}
+              count={TOTAL_CARDS}
+              index={i}
+              // biome-ignore lint/suspicious/noArrayIndexKey: stable order
+              key={i}
+            >
+              <div
+                className="flex h-full w-full items-center justify-center rounded-sm border border-white/10 font-semibold text-[10px] text-white drop-shadow-lg"
+                style={{ backgroundColor: getCardColor(i) }}
+              >
+                {TITLES[i]}
+              </div>
+            </DriftCard>
+          ))}
+        </div>
+      </ReactLenis>
+    </div>
+  );
+}
+
+export default function Drift() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const update = () => {
+      if (containerRef.current) {
+        setDimensions({
+          width: containerRef.current.offsetWidth,
+          height: containerRef.current.offsetHeight,
+        });
+      }
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    if (containerRef.current) {
+      ro.observe(containerRef.current);
+    }
+    return () => ro.disconnect();
+  }, []);
+
+  return (
+    <div
+      className="relative h-96 w-96 overflow-auto rounded-lg bg-black/95"
+      ref={containerRef}
+    >
+      {dimensions.width > 0 && dimensions.height > 0 && (
+        <DriftCards height={dimensions.height} width={dimensions.width} />
+      )}
+    </div>
+  );
+}

--- a/apps/playground/src/animations/folder.tsx
+++ b/apps/playground/src/animations/folder.tsx
@@ -1,0 +1,139 @@
+import { MotionConfig, motion, type Transition } from "motion/react";
+import {
+  createContext,
+  type Dispatch,
+  type SetStateAction,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+const transition: Transition = { type: "spring", bounce: 0, duration: 0.4 };
+
+const Context = createContext<{
+  status: string;
+  setStatus: Dispatch<SetStateAction<string>>;
+}>({ status: "", setStatus: () => null });
+
+function InnerContent() {
+  const ctx = useContext(Context);
+  const isOpen = ctx.status === "open";
+
+  return (
+    <button
+      className="relative aspect-[1.3] h-40 border-0 bg-transparent p-0 md:h-64"
+      onClick={() => {
+        if (isOpen) {
+          ctx.setStatus("idle");
+          return;
+        }
+        ctx.setStatus("open");
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          if (isOpen) {
+            ctx.setStatus("idle");
+            return;
+          }
+          ctx.setStatus("open");
+        }
+      }}
+      type="button"
+    >
+      <motion.div
+        animate={
+          isOpen
+            ? {
+                backgroundImage:
+                  "linear-gradient(to bottom right, #b4e0fa 0%, #399ee6 80%)",
+              }
+            : {}
+        }
+        className="absolute bottom-0 left-0 h-[140px] w-full rounded-[16px] rounded-tl-none shadow-[0_32px_32px_-12px_rgba(0,0,0,0.46)] ring-1 ring-white/25 md:h-[220px] md:rounded-[22px] md:shadow-[0_48px_48px_-16px_rgba(0,0,0,0.46)]"
+        initial={{
+          backgroundImage:
+            "linear-gradient(to bottom right, #b4e0fa 0%, #4eb1e7 100%)",
+        }}
+        style={{ backgroundAttachment: "fixed" }}
+      >
+        <motion.div
+          animate={
+            isOpen
+              ? {
+                  backgroundImage:
+                    "linear-gradient(to bottom right, #b4e0fa 0%, #399ee6 80%)",
+                }
+              : {}
+          }
+          className="absolute -top-4 left-0 h-4 w-[40%] rounded-tl-[16px] rounded-tr-[8px] md:-top-5 md:h-10 md:rounded-tl-[22px] md:rounded-tr-[12px]"
+          initial={{
+            backgroundImage:
+              "linear-gradient(to bottom right, #b4e0fa 0%, #4eb1e7 100%)",
+          }}
+          style={{ backgroundAttachment: "fixed" }}
+        >
+          <motion.div
+            animate={
+              isOpen
+                ? {
+                    backgroundImage:
+                      "linear-gradient(to bottom right, #b4e0fa 0%, #399ee6 100%)",
+                  }
+                : {}
+            }
+            className="absolute top-2 -right-2 size-2 md:top-3 md:-right-3 md:size-3"
+            initial={{
+              backgroundImage:
+                "linear-gradient(to bottom right, #b4e0fa 0%, #4eb1e7 100%)",
+            }}
+            style={{
+              backgroundAttachment: "fixed",
+              maskImage:
+                "radial-gradient(circle 8px at 8px 0px, transparent 0, transparent 8px, black 8px)",
+            }}
+          />
+        </motion.div>
+      </motion.div>
+      <motion.div
+        animate={
+          isOpen
+            ? {
+                transform: "perspective(1100px) rotateX(-70deg)",
+              }
+            : {}
+        }
+        className="absolute bottom-0 left-0 grid h-32 w-full origin-bottom place-items-center rounded-[22px] bg-gradient-to-br from-[#b4e0fa] to-[#4eb1e7] shadow-[0_-1px_1px_1px_rgba(0,0,0,0.06),0_-6px_6px_3px_rgba(0,0,0,0.06),0_-3px_3px_1.5px_rgba(0,0,0,0.06),0_-12px_12px_6px_rgba(0,0,0,0.06),0_-24px_24px_12px_rgba(0,0,0,0.06)] ring-1 ring-white/20 md:h-52"
+        initial={{
+          transform: "perspective(1100px) rotateX(0deg)",
+        }}
+        whileTap={{
+          transform: "perspective(1100px) rotateX(-10deg)",
+        }}
+      />
+    </button>
+  );
+}
+
+export default function Folder() {
+  const [status, setStatus] = useState("idle");
+
+  useEffect(() => {
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setStatus("idle");
+      }
+    }
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, []);
+
+  return (
+    <Context.Provider value={{ status, setStatus }}>
+      <MotionConfig transition={transition}>
+        <main className="relative flex h-72 w-full max-w-2xl items-center justify-center rounded-md border border-muted-foreground/20">
+          <InnerContent />
+        </main>
+      </MotionConfig>
+    </Context.Provider>
+  );
+}

--- a/apps/playground/src/animations/menu.tsx
+++ b/apps/playground/src/animations/menu.tsx
@@ -1,0 +1,230 @@
+import {
+  AnimatePresence,
+  motion,
+  type Transition,
+  type Variants,
+} from "motion/react";
+import { useState } from "react";
+
+const NAV_ITEMS = [
+  { id: "brews", label: "Brews" },
+  { id: "pastries", label: "Pastries" },
+  { id: "beans", label: "Beans" },
+];
+
+const MENUS = {
+  brews: [
+    {
+      title: "Espresso",
+      items: ["Single shot", "Double shot", "Lungo", "Ristretto"],
+    },
+    {
+      title: "Filter",
+      items: ["V60", "Chemex", "Aeropress", "French press"],
+    },
+    {
+      title: "Cold",
+      items: ["Cold brew", "Nitro", "Sparkling", "Iced latte"],
+    },
+  ],
+  pastries: [
+    {
+      title: "Sweet",
+      items: ["Croissant", "Kouign-amann", "Cinnamon roll", "Canelé"],
+    },
+    {
+      title: "Savoury",
+      items: ["Ham & cheese", "Mushroom toast", "Feta danish"],
+    },
+    {
+      title: "Daily",
+      items: ["Monday cookie", "Tuesday loaf", "Weekend tart"],
+    },
+  ],
+  beans: [
+    {
+      title: "Ethiopia",
+      items: ["Yirgacheffe", "Sidamo", "Guji"],
+    },
+    {
+      title: "Colombia",
+      items: ["Huila", "Nariño", "Tolima"],
+    },
+    {
+      title: "Guatemala",
+      items: ["Huehuetenango", "Antigua", "Atitlán"],
+    },
+  ],
+};
+
+const indicatorTransition: Transition = {
+  type: "spring",
+  stiffness: 500,
+  damping: 35,
+};
+const contentTransition: Transition = {
+  type: "spring",
+  stiffness: 300,
+  damping: 30,
+};
+const columnTransition: Transition = {
+  type: "spring",
+  stiffness: 400,
+  damping: 30,
+};
+const panelEnterTransition: Transition = {
+  type: "spring",
+  stiffness: 500,
+  damping: 35,
+};
+const panelExitTransition: Transition = { duration: 0.15, ease: "easeOut" };
+
+const contentOffsetX = 40;
+const columnOffsetY = 8;
+const panelOffsetY = -8;
+const columnStagger = 0.04;
+
+export default function Menu() {
+  const [activeMenu, setActiveMenu] = useState<string | null>(null);
+  const [direction, setDirection] = useState(0);
+
+  const contentVariants: Variants = {
+    enter: (d: number) => ({
+      opacity: 0,
+      x: d ? d * contentOffsetX : 0,
+    }),
+    center: { opacity: 1, x: 0 },
+    exit: (d: number) => ({
+      opacity: 0,
+      x: d ? d * -contentOffsetX : 0,
+    }),
+  };
+
+  const handleHover = (id: string) => {
+    if (activeMenu !== null && activeMenu !== id) {
+      const oldIdx = NAV_ITEMS.findIndex((n) => n.id === activeMenu);
+      const newIdx = NAV_ITEMS.findIndex((n) => n.id === id);
+      setDirection(newIdx > oldIdx ? 1 : -1);
+    } else {
+      setDirection(0);
+    }
+    setActiveMenu(id);
+  };
+
+  const handleLeave = () => {
+    setDirection(0);
+    setActiveMenu(null);
+  };
+
+  return (
+    <div className="flex min-h-[420px] w-full items-start justify-center pt-10">
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: hover-driven mega menu — leave handler on shell wrapper is intentional */}
+      {/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: same as above */}
+      <div className="relative w-[560px] pb-2" onMouseLeave={handleLeave}>
+        <nav className="flex gap-0.5 rounded-xl border border-[#1d2628] bg-[#0b1011] p-1.5">
+          {NAV_ITEMS.map((item) => (
+            <button
+              className="relative flex-1 cursor-pointer border-none bg-transparent px-4 py-2.5 font-medium text-sm transition-colors"
+              key={item.id}
+              onMouseEnter={() => handleHover(item.id)}
+              style={{
+                color:
+                  activeMenu === item.id ? "#f5f5f5" : "rgba(245,245,245,0.5)",
+              }}
+              type="button"
+            >
+              {activeMenu === item.id && (
+                <motion.div
+                  className="absolute inset-0.5 rounded-lg bg-[rgba(131,230,247,0.06)]"
+                  layoutId="menu-indicator"
+                  transition={indicatorTransition}
+                />
+              )}
+              <span className="relative z-10 inline-flex items-center">
+                {item.label}
+                <motion.svg
+                  animate={{ rotate: activeMenu === item.id ? 180 : 0 }}
+                  className="ml-1.5"
+                  fill="none"
+                  height="6"
+                  transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                  viewBox="0 0 10 6"
+                  width="10"
+                >
+                  <path
+                    d="M1 1l4 4 4-4"
+                    stroke="currentColor"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="1.5"
+                  />
+                </motion.svg>
+              </span>
+            </button>
+          ))}
+        </nav>
+
+        <AnimatePresence>
+          {activeMenu && (
+            <motion.div
+              animate={{
+                opacity: 1,
+                y: 0,
+                transition: panelEnterTransition,
+              }}
+              className="absolute top-full right-0 left-0 mt-1 overflow-hidden rounded-xl border border-[#1d2628] bg-[#0b1011] p-6 shadow-[0_12px_40px_rgba(0,0,0,0.35)]"
+              exit={{
+                opacity: 0,
+                y: panelOffsetY,
+                transition: panelExitTransition,
+              }}
+              initial={{ opacity: 0, y: panelOffsetY }}
+              key="panel"
+              style={{ transformOrigin: "top center" }}
+            >
+              <AnimatePresence custom={direction} mode="popLayout">
+                <motion.div
+                  animate="center"
+                  className="grid grid-cols-3 gap-5"
+                  custom={direction}
+                  exit="exit"
+                  initial="enter"
+                  key={activeMenu}
+                  transition={contentTransition}
+                  variants={contentVariants}
+                >
+                  {MENUS[activeMenu as keyof typeof MENUS].map((col, i) => (
+                    <motion.div
+                      animate={{ opacity: 1, y: 0 }}
+                      initial={{
+                        opacity: 0,
+                        y: direction ? 0 : columnOffsetY,
+                      }}
+                      key={col.title}
+                      transition={{
+                        ...columnTransition,
+                        delay: i * columnStagger,
+                      }}
+                    >
+                      <div className="px-2.5 pb-3 font-semibold text-[rgba(245,245,245,0.5)] text-xs uppercase tracking-wider">
+                        {col.title}
+                      </div>
+                      {col.items.map((link) => (
+                        <div
+                          className="cursor-pointer rounded-md px-2.5 py-2 text-[#f5f5f5] text-sm transition-colors hover:bg-white/[0.08]"
+                          key={link}
+                        >
+                          {link}
+                        </div>
+                      ))}
+                    </motion.div>
+                  ))}
+                </motion.div>
+              </AnimatePresence>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/apps/playground/src/animations/morph.tsx
+++ b/apps/playground/src/animations/morph.tsx
@@ -1,0 +1,284 @@
+import { AnimatePresence, LayoutGroup, motion } from "motion/react";
+import { useCallback, useState } from "react";
+
+const cards = [
+  {
+    id: 1,
+    color: "#e74c3c",
+    label: "Red",
+    description: "Warm and energetic — draws attention, evokes passion.",
+  },
+  {
+    id: 2,
+    color: "#3498db",
+    label: "Blue",
+    description: "Calm and trustworthy — associated with depth and stability.",
+  },
+  {
+    id: 3,
+    color: "#2ecc71",
+    label: "Green",
+    description: "Refreshing — symbolises growth and harmony.",
+  },
+  {
+    id: 4,
+    color: "#f39c12",
+    label: "Orange",
+    description: "Vibrant and friendly — radiates warmth and creativity.",
+  },
+  {
+    id: 5,
+    color: "#9b59b6",
+    label: "Purple",
+    description: "Rich and mysterious — linked to imagination and wisdom.",
+  },
+  {
+    id: 6,
+    color: "#1abc9c",
+    label: "Teal",
+    description: "A blend of blue and green that evokes clarity.",
+  },
+];
+
+function makePlaylist(prefix: string) {
+  return [
+    { id: `${prefix}-1`, title: "Track One", artist: "Artist A" },
+    { id: `${prefix}-2`, title: "Track Two", artist: "Artist B" },
+    { id: `${prefix}-3`, title: "Track Three", artist: "Artist C" },
+    { id: `${prefix}-4`, title: "Track Four", artist: "Artist D" },
+    { id: `${prefix}-5`, title: "Track Five", artist: "Artist E" },
+  ];
+}
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = a[i] as T;
+    a[i] = a[j] as T;
+    a[j] = tmp;
+  }
+  return a;
+}
+
+function Toggle({
+  label,
+  enabled,
+  onToggle,
+}: {
+  label: string;
+  enabled: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      className="flex select-none items-center gap-2 rounded-full border px-4 py-2 font-medium text-sm transition-colors"
+      onClick={onToggle}
+      style={{
+        borderColor: enabled ? "#2ecc71" : "#ccc",
+        backgroundColor: enabled ? "#eafaf1" : "#fafafa",
+        color: enabled ? "#1a7a4c" : "#666",
+      }}
+      type="button"
+    >
+      <span
+        className="inline-block h-3 w-3 rounded-full transition-colors"
+        style={{ backgroundColor: enabled ? "#2ecc71" : "#ccc" }}
+      />
+      {label}: {enabled ? "ON" : "OFF"}
+    </button>
+  );
+}
+
+export default function Morph() {
+  const [useLayoutId, setUseLayoutId] = useState(true);
+  const [selectedCard, setSelectedCard] = useState<number | null>(null);
+
+  const [useLayoutGroup, setUseLayoutGroup] = useState(true);
+  const [listA, setListA] = useState(() => makePlaylist("item"));
+  const [listB, setListB] = useState(() => makePlaylist("item"));
+
+  const toggleLayoutId = useCallback(() => {
+    setSelectedCard(null);
+    setUseLayoutId((v) => !v);
+  }, []);
+
+  const selected = cards.find((c) => c.id === selectedCard) ?? null;
+
+  return (
+    <div className="mx-auto w-full max-w-3xl">
+      <section className="mb-16">
+        <h1 className="mb-1 font-bold text-2xl">layoutId</h1>
+        <p className="mb-6 text-neutral-500 text-sm">
+          Two elements with the same <code>layoutId</code> morph between
+          positions.
+        </p>
+
+        <div className="mb-6">
+          <Toggle
+            enabled={useLayoutId}
+            label="Use layoutId"
+            onToggle={toggleLayoutId}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+          {cards.map((card) => (
+            <motion.div
+              className="flex cursor-pointer flex-col items-center justify-center rounded-2xl p-8 text-white shadow-sm"
+              key={card.id}
+              layoutId={useLayoutId ? `morph-card-${card.id}` : undefined}
+              onClick={() => setSelectedCard(card.id)}
+              style={{ backgroundColor: card.color }}
+              whileHover={{ scale: 1.03 }}
+              whileTap={{ scale: 0.98 }}
+            >
+              <span className="font-semibold text-lg">{card.label}</span>
+            </motion.div>
+          ))}
+        </div>
+
+        <AnimatePresence>
+          {selected !== null &&
+            (useLayoutId ? (
+              <motion.div
+                animate={{ backgroundColor: "rgba(0,0,0,0.5)" }}
+                className="fixed inset-0 z-50 flex items-center justify-center p-4"
+                exit={{ backgroundColor: "rgba(0,0,0,0)" }}
+                initial={{ backgroundColor: "rgba(0,0,0,0)" }}
+                key="backdrop"
+                onClick={() => setSelectedCard(null)}
+              >
+                <motion.div
+                  className="flex w-full max-w-md flex-col items-center gap-4 rounded-2xl p-10 text-white shadow-lg"
+                  layoutId={`morph-card-${selected.id}`}
+                  onClick={(e) => e.stopPropagation()}
+                  style={{ backgroundColor: selected.color }}
+                >
+                  <span className="font-bold text-2xl">{selected.label}</span>
+                  <p className="text-center text-sm text-white/80">
+                    {selected.description}
+                  </p>
+                  <button
+                    className="mt-2 rounded-full bg-white/20 px-4 py-1.5 font-medium text-sm backdrop-blur-sm transition-colors hover:bg-white/30"
+                    onClick={() => setSelectedCard(null)}
+                    type="button"
+                  >
+                    Close
+                  </button>
+                </motion.div>
+              </motion.div>
+            ) : (
+              <motion.div
+                animate={{ backgroundColor: "rgba(0,0,0,0.5)" }}
+                className="fixed inset-0 z-50 flex items-center justify-center p-4"
+                exit={{ backgroundColor: "rgba(0,0,0,0)" }}
+                initial={{ backgroundColor: "rgba(0,0,0,0)" }}
+                key="backdrop"
+                onClick={() => setSelectedCard(null)}
+              >
+                <motion.div
+                  animate={{ opacity: 1, scale: 1 }}
+                  className="flex w-full max-w-md flex-col items-center gap-4 rounded-2xl p-10 text-white shadow-lg"
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  onClick={(e) => e.stopPropagation()}
+                  style={{ backgroundColor: selected.color }}
+                  transition={{ type: "spring", duration: 0.5 }}
+                >
+                  <span className="font-bold text-2xl">{selected.label}</span>
+                  <p className="text-center text-sm text-white/80">
+                    {selected.description}
+                  </p>
+                  <button
+                    className="mt-2 rounded-full bg-white/20 px-4 py-1.5 font-medium text-sm backdrop-blur-sm transition-colors hover:bg-white/30"
+                    onClick={() => setSelectedCard(null)}
+                    type="button"
+                  >
+                    Close
+                  </button>
+                </motion.div>
+              </motion.div>
+            ))}
+        </AnimatePresence>
+      </section>
+
+      <section>
+        <h2 className="mb-1 font-bold text-2xl">LayoutGroup</h2>
+        <p className="mb-6 text-neutral-500 text-sm">
+          <code>LayoutGroup</code> with an <code>id</code> namespaces
+          <code>layoutId</code> so identically-named elements don't collide.
+        </p>
+
+        <div className="mb-6">
+          <Toggle
+            enabled={useLayoutGroup}
+            label="Use LayoutGroup"
+            onToggle={() => {
+              setUseLayoutGroup((v) => !v);
+              setListA(makePlaylist("item"));
+              setListB(makePlaylist("item"));
+            }}
+          />
+        </div>
+
+        {useLayoutGroup ? (
+          <div className="flex flex-col gap-4 sm:flex-row">
+            <LayoutGroup id="a">
+              {renderPlaylist("Playlist A", listA, () => setListA(shuffle))}
+            </LayoutGroup>
+            <LayoutGroup id="b">
+              {renderPlaylist("Playlist B", listB, () => setListB(shuffle))}
+            </LayoutGroup>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4 sm:flex-row">
+            {renderPlaylist("Playlist A", listA, () => setListA(shuffle))}
+            {renderPlaylist("Playlist B", listB, () => setListB(shuffle))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function renderPlaylist(
+  title: string,
+  items: { id: string; title: string; artist: string }[],
+  onShuffle: () => void
+) {
+  return (
+    <div className="flex-1 rounded-xl border p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="font-semibold text-neutral-700 text-sm">{title}</h3>
+        <button
+          className="rounded-md border px-3 py-1 font-medium text-neutral-600 text-xs transition-colors hover:bg-neutral-100"
+          onClick={onShuffle}
+          type="button"
+        >
+          Shuffle
+        </button>
+      </div>
+      <ul className="flex flex-col gap-2">
+        {items.map((item, i) => (
+          <motion.li
+            className="flex items-center gap-3 rounded-lg bg-neutral-50 px-3 py-2"
+            key={item.id}
+            layout
+            layoutId={item.id}
+          >
+            <span className="font-medium text-neutral-400 text-xs">
+              {i + 1}
+            </span>
+            <div>
+              <p className="font-medium text-neutral-800 text-sm">
+                {item.title}
+              </p>
+              <p className="text-neutral-500 text-xs">{item.artist}</p>
+            </div>
+          </motion.li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/playground/src/animations/swipe.tsx
+++ b/apps/playground/src/animations/swipe.tsx
@@ -1,0 +1,566 @@
+import {
+  animate,
+  clamp,
+  type MotionValue,
+  motion,
+  useMotionValue,
+  useMotionValueEvent,
+  useSpring,
+  useTransform,
+} from "motion/react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const ITEM_HEIGHT = 80;
+const ITEM_MAX_WIDTH = 384;
+const SPRING_OPTIONS = { stiffness: 900, damping: 80 };
+
+interface IconProps {
+  size?: number;
+}
+
+const MailIcon = ({ size = 24 }: IconProps) => (
+  <svg
+    fill="none"
+    height={size}
+    stroke="currentColor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="1.5"
+    viewBox="0 0 24 24"
+    width={size}
+  >
+    <title>Mail</title>
+    <path d="M3 8l9 6 9-6" />
+    <rect height="14" rx="2" width="18" x="3" y="5" />
+  </svg>
+);
+
+const ClockIcon = ({ size = 24 }: IconProps) => (
+  <svg
+    fill="none"
+    height={size}
+    stroke="currentColor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="1.5"
+    viewBox="0 0 24 24"
+    width={size}
+  >
+    <title>Snooze</title>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 7v5l3 2" />
+  </svg>
+);
+
+const TrashIcon = ({ size = 24 }: IconProps) => (
+  <svg
+    fill="none"
+    height={size}
+    stroke="currentColor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="1.5"
+    viewBox="0 0 24 24"
+    width={size}
+  >
+    <title>Trash</title>
+    <path d="M3 6h18" />
+    <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+    <path d="M10 11v6M14 11v6" />
+  </svg>
+);
+
+const FlagIcon = ({ size = 24 }: IconProps) => (
+  <svg
+    fill="none"
+    height={size}
+    stroke="currentColor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="1.5"
+    viewBox="0 0 24 24"
+    width={size}
+  >
+    <title>Flag</title>
+    <path d="M4 21V4h12l-2 4 2 4H4" />
+  </svg>
+);
+
+const styles = {
+  outerContainer: {
+    padding: 16,
+    cursor: "default",
+  },
+  swipeContainer: {
+    position: "relative",
+    height: ITEM_HEIGHT,
+    width: "80dvw",
+    maxWidth: ITEM_MAX_WIDTH,
+    overflow: "hidden",
+    backgroundColor: "black",
+    borderRadius: 12,
+    border: "1px solid #1d2628",
+    zIndex: 0,
+    touchAction: "none",
+  },
+  swipeItem: {
+    position: "absolute",
+    inset: 0,
+    backgroundColor: "#0b1011",
+    zIndex: 10,
+    display: "flex",
+    alignItems: "center",
+    paddingLeft: 14,
+    paddingRight: 14,
+    gap: 12,
+  },
+  avatar: {
+    width: 36,
+    height: 36,
+    borderRadius: 999,
+    background: "linear-gradient(135deg, #f97316 0%, #db2777 100%)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    color: "#fff",
+    fontWeight: 600,
+    fontSize: 14,
+    flexShrink: 0,
+  },
+  mailBody: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+    minWidth: 0,
+    flex: 1,
+    userSelect: "none",
+    WebkitUserSelect: "none",
+  },
+  mailRow: {
+    display: "flex",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: 8,
+  },
+  mailSender: {
+    fontSize: 13,
+    fontWeight: 600,
+    color: "#f5f5f5",
+  },
+  mailTime: {
+    fontSize: 11,
+    color: "rgba(245,245,245,0.5)",
+    flexShrink: 0,
+  },
+  mailSubject: {
+    fontSize: 12,
+    color: "rgba(245,245,245,0.85)",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  mailPreview: {
+    fontSize: 11,
+    color: "rgba(245,245,245,0.5)",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  actionsGroup: {
+    position: "absolute",
+    height: "100%",
+    width: "100%",
+    userSelect: "none",
+    WebkitUserSelect: "none",
+    display: "flex",
+  },
+  actionFullWidth: {
+    position: "absolute",
+    inset: 0,
+    display: "flex",
+  },
+  actionCenterer: {
+    height: "100%",
+    width: "25%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  actionContent: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 4,
+    flexDirection: "column",
+    color: "#fff",
+    fontSize: 12,
+  },
+} as const satisfies Record<string, React.CSSProperties>;
+
+export default function Swipe() {
+  const [isSwiping, setIsSwiping] = useState(false);
+  const swipeItemRef = useRef<HTMLDivElement>(null);
+  const swipeItemWidth = useRef(0);
+  const swipeStartX = useRef(0);
+  const swipeStartOffset = useRef(0);
+  const fullSwipeSnapPosition = useRef<"left" | "right" | null>(null);
+  const swipeContainerRef = useRef<HTMLDivElement>(null);
+
+  const swipeAmount = useMotionValue(0);
+  const swipeAmountSpring = useSpring(swipeAmount, SPRING_OPTIONS);
+  const swipeProgress = useTransform(swipeAmount, (value) => {
+    const itemWidth = swipeItemWidth.current;
+    if (!itemWidth) {
+      return 0;
+    }
+    return value / itemWidth;
+  });
+
+  useEffect(() => {
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: swipe gesture state machine
+    const handlePointerMove = (info: PointerEvent) => {
+      if (!isSwiping) {
+        return;
+      }
+      const itemWidth = swipeItemWidth.current;
+      if (!itemWidth) {
+        return;
+      }
+
+      const swipeDelta =
+        info.clientX - swipeStartX.current + swipeStartOffset.current;
+      const fullSwipeThreshold = itemWidth * 0.8;
+      const isBeyondThreshold = Math.abs(swipeDelta) > fullSwipeThreshold;
+      const isLeft = swipeDelta < 0;
+
+      if (fullSwipeSnapPosition.current) {
+        const isBackToCenter = Math.abs(swipeDelta) < fullSwipeThreshold;
+        if (isBackToCenter) {
+          fullSwipeSnapPosition.current = null;
+          swipeAmount.set(swipeDelta);
+        } else {
+          const snapPosition =
+            fullSwipeSnapPosition.current === "left" ? -itemWidth : itemWidth;
+          swipeAmount.set(snapPosition);
+        }
+        return;
+      }
+
+      if (isBeyondThreshold) {
+        const snapDirection = isLeft ? "left" : "right";
+        const snapPosition = isLeft ? -itemWidth : itemWidth;
+        fullSwipeSnapPosition.current = snapDirection;
+        swipeAmount.set(snapPosition);
+      } else {
+        swipeAmount.set(clamp(-itemWidth, itemWidth, swipeDelta));
+      }
+    };
+
+    const handlePointerUp = () => {
+      if (!isSwiping) {
+        return;
+      }
+      const itemWidth = swipeItemWidth.current;
+      if (!itemWidth) {
+        return;
+      }
+
+      const currentOffset = swipeAmount.get();
+      let targetOffset = 0;
+      const snapThreshold = itemWidth * 0.25;
+
+      if (Math.abs(currentOffset) > snapThreshold) {
+        targetOffset = currentOffset > 0 ? itemWidth * 0.5 : itemWidth * -0.5;
+      }
+
+      const isFullySwiped = fullSwipeSnapPosition.current;
+      if (isFullySwiped && swipeContainerRef.current) {
+        animate([
+          [
+            swipeContainerRef.current,
+            { scaleY: 1.05, scaleX: 0.95, y: -24, pointerEvents: "none" },
+            { duration: 0.1, ease: "easeOut" },
+          ],
+          [
+            swipeContainerRef.current,
+            { scaleY: 1, scaleX: 1, y: 0, pointerEvents: "auto" },
+            { duration: 0.6, type: "spring" },
+          ],
+        ]);
+        targetOffset = 0;
+        animate(swipeAmount, targetOffset, { duration: 0.5, delay: 0.3 });
+      } else {
+        swipeAmount.set(targetOffset);
+      }
+
+      setIsSwiping(false);
+      fullSwipeSnapPosition.current = null;
+    };
+
+    document.addEventListener("pointermove", handlePointerMove);
+    document.addEventListener("pointerup", handlePointerUp);
+    return () => {
+      document.removeEventListener("pointermove", handlePointerMove);
+      document.removeEventListener("pointerup", handlePointerUp);
+    };
+  }, [isSwiping, swipeAmount]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const newWidth = swipeItemRef.current?.getBoundingClientRect().width;
+      if (!newWidth) {
+        return;
+      }
+      swipeItemWidth.current = newWidth;
+      const currentProgress = swipeProgress.get();
+      const newOffset = currentProgress * newWidth;
+      swipeAmount.jump(newOffset);
+      swipeAmountSpring.jump(newOffset);
+    };
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [swipeAmount, swipeAmountSpring, swipeProgress]);
+
+  return (
+    <div style={styles.outerContainer}>
+      <motion.div
+        onPointerDown={(info) => {
+          setIsSwiping(true);
+          swipeStartX.current = info.clientX;
+          swipeStartOffset.current = swipeAmount.get();
+        }}
+        ref={swipeContainerRef}
+        style={styles.swipeContainer}
+      >
+        <motion.div
+          ref={swipeItemRef}
+          style={{ ...styles.swipeItem, x: swipeAmountSpring }}
+        >
+          <SwipeItemContent swipeProgress={swipeProgress} />
+        </motion.div>
+
+        <ActionsGroup
+          primaryAction={
+            <Action
+              bgColor="#0d63f8"
+              primary
+              side="left"
+              swipeProgress={swipeProgress}
+            >
+              <ActionContent icon={<MailIcon />} label="Read" />
+            </Action>
+          }
+          secondaryAction={
+            <Action bgColor="#9911ff" side="left" swipeProgress={swipeProgress}>
+              <ActionContent icon={<ClockIcon />} label="Remind me" />
+            </Action>
+          }
+          side="left"
+          swipeAmount={swipeAmountSpring}
+        />
+
+        <ActionsGroup
+          primaryAction={
+            <Action
+              bgColor="#ef4444"
+              primary
+              side="right"
+              swipeProgress={swipeProgress}
+            >
+              <ActionContent icon={<TrashIcon />} label="Trash" />
+            </Action>
+          }
+          secondaryAction={
+            <Action
+              bgColor="#f97316"
+              side="right"
+              swipeProgress={swipeProgress}
+            >
+              <ActionContent icon={<FlagIcon />} label="Flag" />
+            </Action>
+          }
+          side="right"
+          swipeAmount={swipeAmountSpring}
+        />
+      </motion.div>
+    </div>
+  );
+}
+
+function ActionsGroup({
+  swipeAmount,
+  side,
+  primaryAction,
+  secondaryAction,
+}: {
+  swipeAmount: MotionValue<number>;
+  side: "left" | "right";
+  primaryAction: React.ReactNode;
+  secondaryAction: React.ReactNode;
+}) {
+  return (
+    <motion.div
+      style={{
+        ...styles.actionsGroup,
+        left: side === "right" ? "100%" : undefined,
+        right: side === "left" ? "100%" : undefined,
+        x: swipeAmount,
+      }}
+    >
+      {secondaryAction}
+      {primaryAction}
+    </motion.div>
+  );
+}
+
+function Action({
+  children,
+  primary = false,
+  swipeProgress,
+  side,
+  bgColor = "#0f1115",
+}: {
+  children: React.ReactNode;
+  primary?: boolean;
+  swipeProgress: MotionValue<number>;
+  side: "left" | "right";
+  bgColor?: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const actionWidth = useRef(0);
+
+  const calculateX = useCallback(
+    (sp: number) => {
+      const width = actionWidth.current;
+      if (primary) {
+        const abs = Math.abs(sp);
+        if (abs >= 0.8) {
+          return 0;
+        }
+        return ((sp * width) / 2) * -1;
+      }
+      return 0;
+    },
+    [primary]
+  );
+
+  const x = useSpring(0, SPRING_OPTIONS);
+  useMotionValueEvent(swipeProgress, "change", (next) => {
+    x.set(calculateX(next));
+  });
+
+  useEffect(() => {
+    const update = () => {
+      const w = ref.current?.getBoundingClientRect().width;
+      if (!w) {
+        return;
+      }
+      actionWidth.current = w;
+      x.jump(calculateX(swipeProgress.get()));
+    };
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, [swipeProgress, x, calculateX]);
+
+  const finalStateOpacity = primary ? 1 : 0;
+  const _opacity = useTransform(
+    swipeProgress,
+    [-1, -0.8, -0.5, -0.25, 0.25, 0.5, 0.8, 1],
+    [finalStateOpacity, 1, 1, 0, 0, 1, 1, finalStateOpacity]
+  );
+  const contentOpacity = useSpring(_opacity, SPRING_OPTIONS);
+
+  const _contentX = useTransform(
+    swipeProgress,
+    [-1, -0.8, -0.5, 0.5, 0.8, 1],
+    [0, 16, 0, 0, -16, 0]
+  );
+  const contentX = useSpring(_contentX, SPRING_OPTIONS);
+
+  const _contentScale = useTransform(
+    swipeProgress,
+    [-1, -0.8, 0, 0.8, 1],
+    [1, 0.8, 1, 0.8, 1]
+  );
+  const contentScale = useSpring(_contentScale, SPRING_OPTIONS);
+
+  return (
+    <motion.div
+      ref={ref}
+      style={{
+        ...styles.actionFullWidth,
+        justifyContent: side === "right" ? "flex-start" : "flex-end",
+        x,
+        backgroundColor: bgColor,
+      }}
+    >
+      <motion.div style={styles.actionCenterer}>
+        <motion.span
+          style={{
+            x: contentX,
+            opacity: contentOpacity,
+            scale: contentScale,
+            transformOrigin: side === "right" ? "right" : "left",
+          }}
+        >
+          {children}
+        </motion.span>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function ActionContent({
+  icon,
+  label,
+}: {
+  icon: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <span style={styles.actionContent}>
+      {icon}
+      {label}
+    </span>
+  );
+}
+
+function SwipeItemContent({
+  swipeProgress,
+}: {
+  swipeProgress: MotionValue<number>;
+}) {
+  const _opacity = useTransform(swipeProgress, [-0.5, 0, 0.5], [0, 1, 0]);
+  const opacity = useSpring(_opacity, SPRING_OPTIONS);
+
+  const _x = useTransform(swipeProgress, [-0.5, 0, 0.5], [40, 0, -40]);
+  const x = useSpring(_x, SPRING_OPTIONS);
+
+  return (
+    <motion.div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        width: "100%",
+        opacity,
+        x,
+      }}
+    >
+      <div style={styles.avatar}>A</div>
+      <div style={styles.mailBody}>
+        <div style={styles.mailRow}>
+          <span style={styles.mailSender}>Alessio</span>
+          <span style={styles.mailTime}>9:42</span>
+        </div>
+        <span style={styles.mailSubject}>Coffee tomorrow?</span>
+        <span style={styles.mailPreview}>
+          Hey — same place at 9? I&apos;ll bring the new beans…
+        </span>
+      </div>
+    </motion.div>
+  );
+}

--- a/apps/playground/src/animations/unfold.tsx
+++ b/apps/playground/src/animations/unfold.tsx
@@ -1,0 +1,11 @@
+export default function Unfold() {
+  return (
+    <div className="relative flex min-h-[28rem] items-center justify-center transition-all duration-300">
+      <div className="group transform-3d translate-3d relative h-96 w-60 border border-blue-300 duration-300 ease-out-cubic hover:-rotate-x-50 hover:-rotate-z-45">
+        <div className="group-hover:-translate-z-20 h-32 w-60 border border-green-300 duration-1000 ease-out-cubic" />
+        <div className="group-hover:-translate-z-20 h-32 w-60 border border-yellow-300 duration-1000 ease-out-cubic" />
+        <div className="group-hover:-translate-z-20 h-32 w-60 border border-purple-300 duration-1000 ease-out-cubic" />
+      </div>
+    </div>
+  );
+}

--- a/apps/playground/src/routeTree.gen.ts
+++ b/apps/playground/src/routeTree.gen.ts
@@ -9,38 +9,64 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as AnimationsRouteRouteImport } from './routes/animations/route'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AnimationsSlugRouteImport } from './routes/animations/$slug'
 
+const AnimationsRouteRoute = AnimationsRouteRouteImport.update({
+  id: '/animations',
+  path: '/animations',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AnimationsSlugRoute = AnimationsSlugRouteImport.update({
+  id: '/$slug',
+  path: '/$slug',
+  getParentRoute: () => AnimationsRouteRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/animations': typeof AnimationsRouteRouteWithChildren
+  '/animations/$slug': typeof AnimationsSlugRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/animations': typeof AnimationsRouteRouteWithChildren
+  '/animations/$slug': typeof AnimationsSlugRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/animations': typeof AnimationsRouteRouteWithChildren
+  '/animations/$slug': typeof AnimationsSlugRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/animations' | '/animations/$slug'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/animations' | '/animations/$slug'
+  id: '__root__' | '/' | '/animations' | '/animations/$slug'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AnimationsRouteRoute: typeof AnimationsRouteRouteWithChildren
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/animations': {
+      id: '/animations'
+      path: '/animations'
+      fullPath: '/animations'
+      preLoaderRoute: typeof AnimationsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -48,11 +74,31 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/animations/$slug': {
+      id: '/animations/$slug'
+      path: '/$slug'
+      fullPath: '/animations/$slug'
+      preLoaderRoute: typeof AnimationsSlugRouteImport
+      parentRoute: typeof AnimationsRouteRoute
+    }
   }
 }
 
+interface AnimationsRouteRouteChildren {
+  AnimationsSlugRoute: typeof AnimationsSlugRoute
+}
+
+const AnimationsRouteRouteChildren: AnimationsRouteRouteChildren = {
+  AnimationsSlugRoute: AnimationsSlugRoute,
+}
+
+const AnimationsRouteRouteWithChildren = AnimationsRouteRoute._addFileChildren(
+  AnimationsRouteRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AnimationsRouteRoute: AnimationsRouteRouteWithChildren,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/playground/src/routes/animations/$slug.tsx
+++ b/apps/playground/src/routes/animations/$slug.tsx
@@ -1,0 +1,67 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import type { ComponentType } from "react";
+import ThreeDStack from "#/animations/3d-stack";
+import Carousel from "#/animations/carousel";
+import Cursor from "#/animations/cursor";
+import Exposure from "#/animations/exposure";
+import FakeThreeDStack from "#/animations/fake-3d-stack";
+import Folder from "#/animations/folder";
+import Menu from "#/animations/menu";
+import Morph from "#/animations/morph";
+import Swipe from "#/animations/swipe";
+import Unfold from "#/animations/unfold";
+
+const ANIMATIONS: Record<string, ComponentType> = {
+  "3d-stack": ThreeDStack,
+  carousel: Carousel,
+  cursor: Cursor,
+  exposure: Exposure,
+  "fake-3d-stack": FakeThreeDStack,
+  folder: Folder,
+  menu: Menu,
+  morph: Morph,
+  swipe: Swipe,
+  unfold: Unfold,
+};
+
+const HINTS: Record<string, string> = {
+  "3d-stack": "scroll inside the stack",
+  carousel: "drag or scroll horizontally",
+  cursor: "move the cursor inside the box",
+  exposure: "drag the strip left or right",
+  "fake-3d-stack": "scroll inside the panel",
+  folder: "click the folder to open",
+  menu: "hover the nav items",
+  morph: "click a card to expand",
+  swipe: "swipe the mail left or right",
+  unfold: "hover the stack",
+};
+
+export const Route = createFileRoute("/animations/$slug")({
+  component: AnimationRoute,
+  loader: ({ params }) => {
+    if (!(params.slug in ANIMATIONS)) {
+      throw notFound();
+    }
+    return { slug: params.slug };
+  },
+});
+
+function AnimationRoute() {
+  const { slug } = Route.useParams();
+  const Component = ANIMATIONS[slug];
+  const hint = HINTS[slug];
+  if (!Component) {
+    return null;
+  }
+  return (
+    <>
+      <Component />
+      {hint && (
+        <p className="fixed bottom-6 left-1/2 -translate-x-1/2 font-mono text-sm opacity-50">
+          {hint}
+        </p>
+      )}
+    </>
+  );
+}

--- a/apps/playground/src/routes/animations/route.tsx
+++ b/apps/playground/src/routes/animations/route.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute, Link, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/animations")({
+  component: AnimationsLayout,
+});
+
+function AnimationsLayout() {
+  return (
+    <main className="relative min-h-screen">
+      <Link
+        className="absolute top-6 left-6 z-50 font-mono text-sm tabular-nums opacity-50 transition-opacity hover:opacity-100"
+        to="/"
+      >
+        ← back
+      </Link>
+      <div className="flex min-h-screen items-center justify-center p-8">
+        <Outlet />
+      </div>
+    </main>
+  );
+}

--- a/apps/playground/src/routes/index.tsx
+++ b/apps/playground/src/routes/index.tsx
@@ -1,14 +1,42 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/")({
   component: Home,
 });
 
+const ANIMATIONS = [
+  "3d-stack",
+  "carousel",
+  "cursor",
+  "exposure",
+  "fake-3d-stack",
+  "folder",
+  "menu",
+  "morph",
+  "swipe",
+  "unfold",
+] as const;
+
 function Home() {
   return (
-    <div className="p-4">
-      <h1 className="font-bold text-2xl">Playground</h1>
-      <p>Code experiments and interactive demos.</p>
-    </div>
+    <main className="min-h-screen px-6 py-12 font-mono sm:px-12 sm:py-20">
+      <h1 className="mb-10 text-sm opacity-50">playground</h1>
+      <ol className="flex flex-col gap-1">
+        {ANIMATIONS.map((slug, i) => (
+          <li key={slug}>
+            <Link
+              className="group flex items-baseline gap-6 text-base tabular-nums opacity-70 transition-opacity hover:opacity-100"
+              params={{ slug }}
+              to="/animations/$slug"
+            >
+              <span className="opacity-50 group-hover:opacity-100">
+                {String(i + 1).padStart(2, "0")}
+              </span>
+              <span>{slug}</span>
+            </Link>
+          </li>
+        ))}
+      </ol>
+    </main>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,8 @@
         "@tanstack/react-start": "latest",
         "@varlock/bitwarden-plugin": "^0.0.6",
         "@varlock/cloudflare-integration": "^0.1.0",
+        "lenis": "^1.3.4",
+        "motion": "^12.38.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "tailwindcss": "^4.2.4",
@@ -210,25 +212,25 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
 
-    "@clack/core": ["@clack/core@1.3.0", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA=="],
+    "@clack/core": ["@clack/core@1.3.1", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA=="],
 
-    "@clack/prompts": ["@clack/prompts@1.3.0", "", { "dependencies": { "@clack/core": "1.3.0", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw=="],
+    "@clack/prompts": ["@clack/prompts@1.4.0", "", { "dependencies": { "@clack/core": "1.3.1", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.2", "", {}, "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="],
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
 
-    "@cloudflare/vite-plugin": ["@cloudflare/vite-plugin@1.33.2", "", { "dependencies": { "@cloudflare/unenv-preset": "2.16.1", "miniflare": "4.20260424.0", "unenv": "2.0.0-rc.24", "wrangler": "4.85.0", "ws": "8.18.0" }, "peerDependencies": { "vite": "^6.1.0 || ^7.0.0 || ^8.0.0" } }, "sha512-XI6+XkDn8W6tlvtYUoS6C89Te7fwhyDLrhUBUbagPO1StJ6ofbR0vpqNNqNskUp9592xTRCDk5ukqcjz6xMo+g=="],
+    "@cloudflare/vite-plugin": ["@cloudflare/vite-plugin@1.37.1", "", { "dependencies": { "@cloudflare/unenv-preset": "2.16.1", "miniflare": "4.20260515.0", "unenv": "2.0.0-rc.24", "wrangler": "4.92.0", "ws": "8.18.0" }, "peerDependencies": { "vite": "^6.1.0 || ^7.0.0 || ^8.0.0" } }, "sha512-FldhsmkXyLsX3yI+p0aJDo/kGyY69pDdynz2JjcuH3eCiQ+G9XaY3CrN+UYEfCbWv8CiR2wL95lNg0fT/HfwWA=="],
 
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260424.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-yFR1XaJbSDLg/qbwtrYaU2xwFXatIPKR5nrMQCN1q/m6+Qe/j6r+kCnFEvOJjMZOm9iCKsE6Qly5clgl4u32qw=="],
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260421.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-DLU5ZTZ1VHeZZnj0PuVJEMHKGisfLe2XShyImP5P/PPj/m/t7CLEJmPiI7FMxvT7ynArkckJl7m+Z5x7u4Kkdw=="],
 
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260424.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LqWKcE7x/9KyC2iQvKPeb20hKST3dYXDZlYTvFymgR1DfLS0OFOCzVGTloVNd7WqvK4SkdzBYfxo7QMIAeBK0w=="],
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260421.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Trotq3xRAkIcpC505WoxM8+kIH4JIvOJCNuRatyHcz9uF5S+ukgiVUFUlM+GIjw1uCM/Bda2St+vSniX1RZdpw=="],
 
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260424.1", "", { "os": "linux", "cpu": "x64" }, "sha512-YlEBFbAYZHe/ylzl8WEYQEU/jr+0XMqXaST2oBk5oVjksdb1NGuJaggluCdZAzuJJ8UqdTmyhY5u/qrasbiFWA=="],
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260421.1", "", { "os": "linux", "cpu": "x64" }, "sha512-938QjUv0z+QqK6BAvgwX/lCIZ2b224ZXoXtGTbhyNVMhB+mt4Dj24cj9qca4ekNXjVM7uTKp1yOHZO97fVSacw=="],
 
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260424.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-qJ0X0m6cL8fWDUPDg8K4IxYZXNJI6XbeOihqjnqKbAClrjdPDn8VUSd+z2XiCQ5NylMtMrpa/skC9UfaR6mh8g=="],
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260421.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-YI4+mLfwnJcKJ+iPyxzx+tp2Jy4o29BxBPSQGZxl/AZyvZ9eTKsmNZmtjEiT4i3O/M0tdO/B/d9ESDHbRCs2rQ=="],
 
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260424.1", "", { "os": "win32", "cpu": "x64" }, "sha512-tZ7Z9qmYNAP6z1/+8r/zKbk8F8DZmpmwNzMeN+zkde2Wnhfr3FBqOkJXT/5zmli8HPoWrIXxSiyqcNDMy8V2Zg=="],
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260421.1", "", { "os": "win32", "cpu": "x64" }, "sha512-q1SFgwlNH9lFmw74vh7EJbJtduo92Nx51mNOfd3/u6pux6AldcwRviYzKEEv3FEbtv6OBB7J8D5f8vtZj7Z6Sg=="],
 
     "@content-collections/core": ["@content-collections/core@0.15.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "camelcase": "^8.0.0", "chokidar": "^4.0.3", "esbuild": "^0.25.11", "gray-matter": "^4.0.3", "p-limit": "^6.1.0", "picomatch": "^4.0.2", "pluralize": "^8.0.0", "serialize-javascript": "^7.0.3", "tinyglobby": "^0.2.5", "yaml": "^2.4.5" }, "peerDependencies": { "typescript": "^5.0.2 || ^6.0.0" } }, "sha512-GCbG7p+7cGnPUAyoOPoT8ABsd9D6VWF17YJUl+IHJWr+VYTYNKyDaQtJ+6Pfg55GvtuW3gCfqJkOx6Pu2SB6YA=="],
 
@@ -438,7 +440,7 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+    "@oxc-project/types": ["@oxc-project/types@0.130.0", "", {}, "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -476,35 +478,35 @@
 
     "@repo/ui": ["@repo/ui@workspace:packages/ui"],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.17", "", { "os": "android", "cpu": "arm64" }, "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.1", "", { "os": "android", "cpu": "arm64" }, "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "x64" }, "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.17", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm" }, "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.1", "", { "os": "linux", "cpu": "arm" }, "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "ppc64" }, "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "s390x" }, "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.17", "", { "os": "none", "cpu": "arm64" }, "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.1", "", { "os": "none", "cpu": "arm64" }, "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.17", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.1", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "arm64" }, "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "x64" }, "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.1", "", { "os": "win32", "cpu": "x64" }, "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
@@ -598,41 +600,41 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.4", "", { "dependencies": { "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "tailwindcss": "4.2.4" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw=="],
 
-    "@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
+    "@tanstack/history": ["@tanstack/history@1.162.0", "", {}, "sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA=="],
 
-    "@tanstack/react-router": ["@tanstack/react-router@1.169.1", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.169.1", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-MBtQKSvac3OCcsSa6oBpDrrN90IV47I6Gtv05NxhbFVh+gVjtqvs6HSU4XM9+y5sHZPgS+35eArflX4vM8GEnQ=="],
+    "@tanstack/react-router": ["@tanstack/react-router@1.170.4", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.2", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-cusL4YCTuGGJhjfsXEBm6/SmOAs/G8wRVNadeyN3ofu4OZwX69KAybBEf217buxYzI+FohdJVoigEpJV+tGzIw=="],
 
-    "@tanstack/react-start": ["@tanstack/react-start@1.167.62", "", { "dependencies": { "@tanstack/react-router": "1.169.1", "@tanstack/react-start-client": "1.166.47", "@tanstack/react-start-rsc": "0.0.41", "@tanstack/react-start-server": "1.166.51", "@tanstack/router-utils": "1.161.7", "@tanstack/start-client-core": "1.168.1", "@tanstack/start-plugin-core": "1.169.17", "@tanstack/start-server-core": "1.167.29", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-ZBLl/WLxE0l4X7hncqwQaw69le+Ct8NZPKuyRgi9sY1pR1fK+QFYkb396w3+LNIdgGe/6p+tqjvqoUAa8+G/Bw=="],
+    "@tanstack/react-start": ["@tanstack/react-start@1.168.6", "", { "dependencies": { "@tanstack/react-router": "1.170.4", "@tanstack/react-start-client": "1.167.4", "@tanstack/react-start-rsc": "0.1.6", "@tanstack/react-start-server": "1.167.4", "@tanstack/router-utils": "1.162.0", "@tanstack/start-client-core": "1.169.4", "@tanstack/start-plugin-core": "1.170.6", "@tanstack/start-server-core": "1.168.4", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-0/vMhec98zdBvcagQB3NKuz4jZX3Z/djOXjpMLeQclYMRWqbj5XA0WBAFLCuA8p84eUoP8yiUkEDH1OUfIYf7A=="],
 
-    "@tanstack/react-start-client": ["@tanstack/react-start-client@1.166.47", "", { "dependencies": { "@tanstack/react-router": "1.169.1", "@tanstack/router-core": "1.169.1", "@tanstack/start-client-core": "1.168.1" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-9g2BRXcB8ODsytbJpxxJfk73hAPrHAlb3UHSeelDnufh9c147hgjdhQj8gG9/KwXXLCS6AwAZMEbB/Mwn62qWA=="],
+    "@tanstack/react-start-client": ["@tanstack/react-start-client@1.167.4", "", { "dependencies": { "@tanstack/react-router": "1.170.4", "@tanstack/router-core": "1.171.2", "@tanstack/start-client-core": "1.169.4" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-HYr9kbEuXjoqEVhmkuIXK9ckfrx08nHCPQ+PQbZlwHd01wghljcBsdAe/8/xujiKnbihC05owBDmXQoE3v27bQ=="],
 
-    "@tanstack/react-start-rsc": ["@tanstack/react-start-rsc@0.0.41", "", { "dependencies": { "@tanstack/react-router": "1.169.1", "@tanstack/react-start-server": "1.166.51", "@tanstack/router-core": "1.169.1", "@tanstack/router-utils": "1.161.7", "@tanstack/start-client-core": "1.168.1", "@tanstack/start-fn-stubs": "1.161.6", "@tanstack/start-plugin-core": "1.169.17", "@tanstack/start-server-core": "1.167.29", "@tanstack/start-storage-context": "1.166.34", "pathe": "^2.0.3" }, "peerDependencies": { "@rspack/core": ">=2.0.0-0", "@vitejs/plugin-rsc": ">=0.5.20", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "react-server-dom-rspack": ">=0.0.2" }, "optionalPeers": ["@rspack/core", "@vitejs/plugin-rsc", "react-server-dom-rspack"] }, "sha512-0l1bZZfWhdT0lT6cWD6jtLs0A3u+9hSzOjIVanm7dj+XHfkqbV8m9i4Bni+3JsIObICmhed9A6wqkERWe4kgAw=="],
+    "@tanstack/react-start-rsc": ["@tanstack/react-start-rsc@0.1.6", "", { "dependencies": { "@tanstack/react-router": "1.170.4", "@tanstack/react-start-server": "1.167.4", "@tanstack/router-core": "1.171.2", "@tanstack/router-utils": "1.162.0", "@tanstack/start-client-core": "1.169.4", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-plugin-core": "1.170.6", "@tanstack/start-server-core": "1.168.4", "@tanstack/start-storage-context": "1.167.4", "pathe": "^2.0.3" }, "peerDependencies": { "@rspack/core": ">=2.0.0-0", "@vitejs/plugin-rsc": ">=0.5.20", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "react-server-dom-rspack": ">=0.0.2" }, "optionalPeers": ["@rspack/core", "@vitejs/plugin-rsc", "react-server-dom-rspack"] }, "sha512-EIP5Vnc4quTZm5rhhkHAqANHGaXRks+S3FomGMHcN7noTJ3OZviifJXc1nN8pYSFeP8NQ2Sqrkn1Kr/87iWXWA=="],
 
-    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.166.51", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-router": "1.169.1", "@tanstack/router-core": "1.169.1", "@tanstack/start-client-core": "1.168.1", "@tanstack/start-server-core": "1.167.29" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-5pUZCuNyqE06MbWE27+AoNFvcEQb6XbtXKm+yt1Dvd0/bijkN0LVBtV0sX+qqx+lMUtr5HOOCbRMAvDGYYgSyw=="],
+    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.167.4", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-router": "1.170.4", "@tanstack/router-core": "1.171.2", "@tanstack/start-client-core": "1.169.4", "@tanstack/start-server-core": "1.168.4" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-FckuV/6uQQqycU8ufTtxyQiY4hL3bGn23kq/XFsJVXWtpflY6LAtfOi23CoRL4G8eTVvUa2+WGReZhivwNGZiw=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
-    "@tanstack/router-core": ["@tanstack/router-core@1.169.1", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.0", "seroval-plugins": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-x+2gIGKTTE1qAn7tLieGfrB5ciOviDmmi2ox9fAWUubRV+yTU5ruGFXocoCIWF+lB+SOtnHjo2E9BLSWyYoEmA=="],
+    "@tanstack/router-core": ["@tanstack/router-core@1.171.2", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-sUd+BhGYkBF64LVhmOHnYsc1AutPNch/huohEXiXL4IUgmk17Gy+RkUazvjQhptVdYW5QT+qtATrUr2cQZNHFA=="],
 
-    "@tanstack/router-generator": ["@tanstack/router-generator@1.166.39", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.169.1", "@tanstack/router-utils": "1.161.7", "@tanstack/virtual-file-routes": "1.161.7", "jiti": "^2.6.1", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^3.24.2" } }, "sha512-j2OW/UvpjM/DT9tHVmuhWW1k6UOezTRrPqBPZFFmIth0fY7iTPqK+Erqpo8r5yGTRGCbMvOS4sL3H2MldnIZew=="],
+    "@tanstack/router-generator": ["@tanstack/router-generator@1.167.5", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.2", "@tanstack/router-utils": "1.162.0", "@tanstack/virtual-file-routes": "1.162.0", "jiti": "^2.7.0", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^3.24.2" } }, "sha512-S7h9qs7WjwF1IlMiOxSv+xB/bSOQ6QS84NlApM9iWLVdkbOVUn7RzTaCqw2qdDa5cPrfSiZJ2wK2a6RFDmFubA=="],
 
-    "@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.32", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.169.1", "@tanstack/router-generator": "1.166.39", "@tanstack/router-utils": "1.161.7", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^3.0.0", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.169.1", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"], "bin": { "intent": "bin/intent.js" } }, "sha512-i9BA6GzUCoM20UYZ77orXzHwD5zM0OQTtLuPNbqTTSG38CvR6viRFP/d+QFo2aRNyCvun8PR7zSa49bslSggEQ=="],
+    "@tanstack/router-plugin": ["@tanstack/router-plugin@1.168.6", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.2", "@tanstack/router-generator": "1.167.5", "@tanstack/router-utils": "1.162.0", "@tanstack/virtual-file-routes": "1.162.0", "chokidar": "^3.6.0", "unplugin": "^3.0.0", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.170.4", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"] }, "sha512-u5CNtTWGyFvV8gGWKBt9LdwVGg+ISSBXG/aeeU1/d1YpEKPqlJHS6oN3tvNKOScubeV64HjpeV0tD6fqRfCpvw=="],
 
-    "@tanstack/router-utils": ["@tanstack/router-utils@1.161.7", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-VkY0u7ax/GD0qU6ZLLnfPC+UMxVzxRbvZp4yV4iUSXjgJZ/siAT5/QlLm9FEDJ9QDoC0VD9W7f00tKKreUI7Ng=="],
+    "@tanstack/router-utils": ["@tanstack/router-utils@1.162.0", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-c3GhqhBRCP636B41nf3TKvVz8EWzC5PTZ3I4J4LDH2tVjpxbyFNYsQKRtbNWiMFl+GTtgK4nCha346Wv7j4hcQ=="],
 
-    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.168.1", "", { "dependencies": { "@tanstack/router-core": "1.169.1", "@tanstack/start-fn-stubs": "1.161.6", "@tanstack/start-storage-context": "1.166.34", "seroval": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-P0gtOPMzHONjDP0fLL7NWJ25MWBrwxh45tMObgzKH7ziHXciB1s3eiUUjNWISr/vcPXVptppgaBVJ8IGZpR1fQ=="],
+    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.169.4", "", { "dependencies": { "@tanstack/router-core": "1.171.2", "@tanstack/start-fn-stubs": "1.162.0", "@tanstack/start-storage-context": "1.167.4", "seroval": "^1.5.4" } }, "sha512-2UZ1hLCY80eXkYjRLYASLiJqDXfmlCE3kUknNARgZr7232TMk4ADPDMCp2l506zLXTLKAnI+Wu4jXL2CEadUxQ=="],
 
-    "@tanstack/start-fn-stubs": ["@tanstack/start-fn-stubs@1.161.6", "", {}, "sha512-Y6QSlGiLga8cHfvxGGaonXIlt2bIUTVdH6AMjmpMp7+ANNCp+N96GQbjjhLye3JkaxDfP68x5iZA8NK4imgRig=="],
+    "@tanstack/start-fn-stubs": ["@tanstack/start-fn-stubs@1.162.0", "", {}, "sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ=="],
 
-    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.169.17", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@rolldown/pluginutils": "1.0.0-beta.40", "@tanstack/router-core": "1.169.1", "@tanstack/router-generator": "1.166.39", "@tanstack/router-plugin": "1.167.32", "@tanstack/router-utils": "1.161.7", "@tanstack/start-client-core": "1.168.1", "@tanstack/start-server-core": "1.167.29", "cheerio": "^1.0.0", "exsolve": "^1.0.7", "lightningcss": "^1.32.0", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.5.0", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-9VIDnVAu3h/JYqYBbrNBgDpg37uWLbOM2tZgMoLIuW/oXbyv70Iy68NthNqgISnGWrrPyuRs3wcGwYdaPrUw4A=="],
+    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.170.6", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@rolldown/pluginutils": "1.0.0-beta.40", "@tanstack/router-core": "1.171.2", "@tanstack/router-generator": "1.167.5", "@tanstack/router-plugin": "1.168.6", "@tanstack/router-utils": "1.162.0", "@tanstack/start-client-core": "1.169.4", "@tanstack/start-server-core": "1.168.4", "cheerio": "^1.0.0", "exsolve": "^1.0.7", "lightningcss": "^1.32.0", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.5.4", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-8XzrZwNvYODjTf6zByQhYd1286YU8O1iecZ2zMhchvkHLTLfvku8xJavjLTaz9MAMM08KiX/oqEwpRiP/aOalg=="],
 
-    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.167.29", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.169.1", "@tanstack/start-client-core": "1.168.1", "@tanstack/start-storage-context": "1.166.34", "fetchdts": "^0.1.6", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.5.0" } }, "sha512-ZuTrFOIbmNh9wL3W6hOfHmcvcJaxoLOGw4rMRY4J9D0Ue756+l9ub6hjqKVRcNxB43gc9ewE0mQiE8ofANjo1A=="],
+    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.168.4", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/router-core": "1.171.2", "@tanstack/start-client-core": "1.169.4", "@tanstack/start-storage-context": "1.167.4", "fetchdts": "^0.1.6", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.5.4" } }, "sha512-YF9HRjIh8SyprQxOiAB1puXkGI4PqF2/StX00CXtmLOphFTfuShYOPvmQZXl2XZp6H9vt+qY+BNXucSuLzag9g=="],
 
-    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.166.34", "", { "dependencies": { "@tanstack/router-core": "1.169.1" } }, "sha512-mIre+HDvahOnUmP3vQx+x4kvUzam/uVYpCphudR/Czzi0Crfm0JyyLMNv7hHxkfqMg9aTrxYtDTZHR3isrUKhg=="],
+    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.167.4", "", { "dependencies": { "@tanstack/router-core": "1.171.2" } }, "sha512-hI93yABbvcaMWkCtewjxNAZOXcJIWhh7P8um7A76OHA2LmLFaR36Sm8eZ6OQHhPdFob4DMOkwDiCv9sckRvCow=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
-    "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
+    "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
 
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg=="],
 
@@ -664,7 +666,7 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-    "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
+    "@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -864,8 +866,6 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
-    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
-
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
@@ -953,6 +953,8 @@
     "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw=="],
 
     "lefthook-windows-x64": ["lefthook-windows-x64@2.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A=="],
+
+    "lenis": ["lenis@1.3.23", "", { "peerDependencies": { "@nuxt/kit": ">=3.0.0", "react": ">=17.0.0", "vue": ">=3.0.0" }, "optionalPeers": ["@nuxt/kit", "react", "vue"] }, "sha512-YxYq3TJqj9sJNv0V9SkyQHejt14xwyIwgDaaMK89Uf9SxQfIszu+gTQSSphh6BWlLTNVKvvXAGkg+Zf+oFIevg=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -1062,7 +1064,7 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
-    "miniflare": ["miniflare@4.20260424.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260424.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-B6MKBBd5TJ19daUc3Ae9rWctn1nDA/VCXykXfCsp9fTxyfGxnZY27tJs1caxgE9MWEMMKGbGHouqVtgKbKGxmw=="],
+    "miniflare": ["miniflare@4.20260515.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260515.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-2j0oQWizk1Eu4Cm8tDX7Z+Nsjd0nebIj1TQcQ+Oy1QKeo0Ay9+bdn8wfLAtOj9znDCybDCUlnS1+nYvKXEdfNg=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -1154,9 +1156,7 @@
 
     "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
-    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
-
-    "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
+    "rolldown": ["rolldown@1.0.1", "", { "dependencies": { "@oxc-project/types": "=0.130.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.1", "@rolldown/binding-darwin-arm64": "1.0.1", "@rolldown/binding-darwin-x64": "1.0.1", "@rolldown/binding-freebsd-x64": "1.0.1", "@rolldown/binding-linux-arm-gnueabihf": "1.0.1", "@rolldown/binding-linux-arm64-gnu": "1.0.1", "@rolldown/binding-linux-arm64-musl": "1.0.1", "@rolldown/binding-linux-ppc64-gnu": "1.0.1", "@rolldown/binding-linux-s390x-gnu": "1.0.1", "@rolldown/binding-linux-x64-gnu": "1.0.1", "@rolldown/binding-linux-x64-musl": "1.0.1", "@rolldown/binding-openharmony-arm64": "1.0.1", "@rolldown/binding-wasm32-wasi": "1.0.1", "@rolldown/binding-win32-arm64-msvc": "1.0.1", "@rolldown/binding-win32-x64-msvc": "1.0.1" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ=="],
 
     "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
 
@@ -1172,9 +1172,9 @@
 
     "serialize-javascript": ["serialize-javascript@7.0.5", "", {}, "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw=="],
 
-    "seroval": ["seroval@1.5.2", "", {}, "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q=="],
+    "seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
 
-    "seroval-plugins": ["seroval-plugins@1.5.2", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg=="],
+    "seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
@@ -1230,8 +1230,6 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
-
     "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
@@ -1244,7 +1242,7 @@
 
     "undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
 
-    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
@@ -1274,7 +1272,7 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
+    "vite": ["vite@8.0.13", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.1", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw=="],
 
     "vite-tsconfig-paths": ["vite-tsconfig-paths@6.1.1", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" } }, "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg=="],
 
@@ -1290,9 +1288,9 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "workerd": ["workerd@1.20260424.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260424.1", "@cloudflare/workerd-darwin-arm64": "1.20260424.1", "@cloudflare/workerd-linux-64": "1.20260424.1", "@cloudflare/workerd-linux-arm64": "1.20260424.1", "@cloudflare/workerd-windows-64": "1.20260424.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-oKsB0Xo/mfkYMdSACoS06XZg09VUK4rXwHfF/1t3P++sMbwzf4UHQvMO57+zxpEB2nVrY/ZkW0bYFGq4GdAFSQ=="],
+    "workerd": ["workerd@1.20260421.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260421.1", "@cloudflare/workerd-darwin-arm64": "1.20260421.1", "@cloudflare/workerd-linux-64": "1.20260421.1", "@cloudflare/workerd-linux-arm64": "1.20260421.1", "@cloudflare/workerd-windows-64": "1.20260421.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-zTYD+xFR4d7TUCxsyl7FTPth9a8CDgk8pM7xUWbJxo0SGUx+2e5C7Q5LrramBZwmuAErtzXmOjlQ15PtkPAhZA=="],
 
-    "wrangler": ["wrangler@4.85.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260424.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260424.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260424.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-93cwt2RPb1qdcmEgPzH7ybiLN4BIKoWpscIX6SywjHrQOeIZrQk2haoc3XMLKtQTmzapxza9OuDD+kMHpsuuhg=="],
+    "wrangler": ["wrangler@4.84.1", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260421.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260421.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260421.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-Xe1S/Bik7pNdtdJ+asHsEZC2dX9k3WxYn2BbxFtOrrLVxN/LKi750zsrjX41jSAk00M/O1l7jzyQV4sQqw8ftg=="],
 
     "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
@@ -1304,7 +1302,7 @@
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
@@ -1314,7 +1312,7 @@
 
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
-    "zod": ["zod@4.4.2", "", {}, "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
@@ -1329,6 +1327,8 @@
     "@babel/template/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@cloudflare/vite-plugin/wrangler": ["wrangler@4.92.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260515.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260515.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260515.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-/DKpQHPxkuZbQsO9dFW2700VTD/4DSZMHjy92fO/frNoDRi/zQsFCAd2ONCV6TGqcUoXcP3D8Bo2gj/L4M0qQQ=="],
 
     "@content-collections/core/yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
@@ -1358,6 +1358,8 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@tanstack/router-generator/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
     "@tanstack/router-generator/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@tanstack/router-plugin/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
@@ -1374,77 +1376,49 @@
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
+    "miniflare/workerd": ["workerd@1.20260515.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260515.1", "@cloudflare/workerd-darwin-arm64": "1.20260515.1", "@cloudflare/workerd-linux-64": "1.20260515.1", "@cloudflare/workerd-linux-arm64": "1.20260515.1", "@cloudflare/workerd-windows-64": "1.20260515.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-MjKOJLcvU45xXedQowvuiHtJTxu4WTHYQeIlF7YmjuqhiI6dImTFxWCEoRQHiskztxuVSNEmdO7/0UfDu6OMnQ=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "protobufjs/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
-    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
-
-    "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
     "ultracite/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "vite/postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg=="],
 
     "wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
+    "wrangler/miniflare": ["miniflare@4.20260421.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260421.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-7ZkNQ7brgQ2hh5ha9iQCDUjxBkLvuiG2VdDns9esRL8O8lXg+MoP6E0dO1rtp+ZY2I+vV1tPWr6td5IojkewLw=="],
+
     "xmlbuilder2/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "@cloudflare/vite-plugin/wrangler/@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "@cloudflare/vite-plugin/wrangler/workerd": ["workerd@1.20260515.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260515.1", "@cloudflare/workerd-darwin-arm64": "1.20260515.1", "@cloudflare/workerd-linux-64": "1.20260515.1", "@cloudflare/workerd-linux-arm64": "1.20260515.1", "@cloudflare/workerd-windows-64": "1.20260515.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-MjKOJLcvU45xXedQowvuiHtJTxu4WTHYQeIlF7YmjuqhiI6dImTFxWCEoRQHiskztxuVSNEmdO7/0UfDu6OMnQ=="],
 
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
-    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+    "miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260515.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Wtw44el2pNbzixvTkWdfeBDTrQwQbJRz7/JUvPKV27I0pQWXbhNJPpM8cstq/pbrU5AGcA/HjFH6yPMRTIRKig=="],
 
-    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+    "miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260515.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-X8EqkZej6FfmhF9AVAQ3FhyQRr9acS4RcDunMU2YiuxKHF1IU8zzH3vY30/POaG+rUu9vGDp/VgUl49VPenHJQ=="],
 
-    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+    "miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260515.1", "", { "os": "linux", "cpu": "x64" }, "sha512-CDC89QxQ7Y7t7RG1Jd9vj/qolE1sQRkI2OSEuV5BMJi0vW/gV4OVG6xjpdK3b1OYnSWDzF7NpvlR5Yg86q7k4g=="],
 
-    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+    "miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260515.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WxbW/PToYES4fvHXzsr/5qOiETQs/Z9iZ0mjSZAiEwq5cMLZemzGN0COx+uFb9OvQwzh6Pg159qPFnw3+i9FuA=="],
 
-    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+    "miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260515.1", "", { "os": "win32", "cpu": "x64" }, "sha512-WmV/iv+MHjYsvkcMVzpM2B5/mf06UUkdpVhZrtMfV9graWjBGPYFvE/eab8748RPVGKh1Xe1vXofLzDSwc08lA=="],
 
-    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
-
-    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
-
-    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
-
-    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
-
-    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
-
-    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
-
-    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
-
-    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
-
-    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
-
-    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
-
-    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
-
-    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
-
-    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
-
-    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
-
-    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
-
-    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
-
-    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
-
-    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
-
-    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
-
-    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
-
-    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+    "protobufjs/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
@@ -1499,6 +1473,68 @@
     "wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
     "xmlbuilder2/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
+    "@cloudflare/vite-plugin/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260515.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Wtw44el2pNbzixvTkWdfeBDTrQwQbJRz7/JUvPKV27I0pQWXbhNJPpM8cstq/pbrU5AGcA/HjFH6yPMRTIRKig=="],
+
+    "@cloudflare/vite-plugin/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260515.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-X8EqkZej6FfmhF9AVAQ3FhyQRr9acS4RcDunMU2YiuxKHF1IU8zzH3vY30/POaG+rUu9vGDp/VgUl49VPenHJQ=="],
+
+    "@cloudflare/vite-plugin/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260515.1", "", { "os": "linux", "cpu": "x64" }, "sha512-CDC89QxQ7Y7t7RG1Jd9vj/qolE1sQRkI2OSEuV5BMJi0vW/gV4OVG6xjpdK3b1OYnSWDzF7NpvlR5Yg86q7k4g=="],
+
+    "@cloudflare/vite-plugin/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260515.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WxbW/PToYES4fvHXzsr/5qOiETQs/Z9iZ0mjSZAiEwq5cMLZemzGN0COx+uFb9OvQwzh6Pg159qPFnw3+i9FuA=="],
+
+    "@cloudflare/vite-plugin/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260515.1", "", { "os": "win32", "cpu": "x64" }, "sha512-WmV/iv+MHjYsvkcMVzpM2B5/mf06UUkdpVhZrtMfV9graWjBGPYFvE/eab8748RPVGKh1Xe1vXofLzDSwc08lA=="],
 
     "@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
   }


### PR DESCRIPTION
Each animation gets its own /animations/<slug> route via a dynamic $slug file, with a shared layout (back link, bottom CTA hint) and the index listing every entry. View transitions are inherited from the existing router config.

Adds motion + lenis deps.